### PR TITLE
Add create_artifact_guided_one_file

### DIFF
--- a/ClimaArtifactsHelper.jl/Project.toml
+++ b/ClimaArtifactsHelper.jl/Project.toml
@@ -5,6 +5,7 @@ version = "0.0.1"
 
 [deps]
 ArtifactUtils = "8b73e784-e7d8-4ea5-973d-377fed4e3bce"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"

--- a/ClimaArtifactsHelper.jl/src/ClimaArtifactsHelper.jl
+++ b/ClimaArtifactsHelper.jl/src/ClimaArtifactsHelper.jl
@@ -5,8 +5,9 @@ using REPL.TerminalMenus
 using Pkg.Artifacts
 
 import SHA: sha1
+import Downloads: download
 
-export create_artifact_guided
+export create_artifact_guided, create_artifact_guided_one_file
 
 const MB = 1024 * 1024
 
@@ -160,6 +161,38 @@ function create_artifact_guided(artifact_dir; artifact_name)
     println("Artifact string saved to $output_artifacts")
     println("Feel free to add other metadata/properties (e.g., laziness)")
     println("Enjoy the rest of your day!")
+end
+
+"""
+    create_artifact_guided_one_file(file_path; artifact_name, file_url)
+
+Start a guided process to create an artifact from one file.
+
+If the file is not present at `file_path`, it will be downloaded from `file_url`.
+"""
+function create_artifact_guided_one_file(
+    file_path;
+    artifact_name,
+    file_url = nothing,
+)
+
+    output_dir = artifact_name
+
+    if isdir(output_dir)
+        @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
+        @warn "Abort this calculation, unless you know what you are doing."
+    else
+        mkdir(output_dir)
+    end
+
+    if !isfile(file_path)
+        isnothing(file_url) && error("File not found but file url not provided")
+        @info "$file_path not found, downloading it (might take a while)"
+        downloaded_file = download(file_url)
+        Base.mv(downloaded_file, file_path)
+    end
+
+    create_artifact_guided(output_dir; artifact_name)
 end
 
 end


### PR DESCRIPTION
Helper function to fetch one single file. Example:

```
using ClimaArtifactsHelper

const FILE_URL = "https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata/lnd/clm2/surfdata_map/surfdata_0.9x1.25_hist_17pfts_nocft_CMIP6_simyr1700_c230809.nc"
const FILE_PATH = "surfdata_0.9x1.25_hist_17pfts_nocft_CMIP6_simyr1700_c230809.nc"

create_artifact_guided_one_file(FILE_PATH; artifact_name = basename(@__DIR__), file_url = FILE_URL)
```