### PR TITLE
correct the link in model rmse artifact

### DIFF
--- a/cmip_model_rmse/OutputArtifacts.toml
+++ b/cmip_model_rmse/OutputArtifacts.toml
@@ -1,6 +1,6 @@
 [cmip_model_rmse]
-git-tree-sha1 = "aa2d5178a656e9ce7a37698d978d8ed92aa46d99"
+git-tree-sha1 = "53a27731c0a2ec60756af24e4c60ac37da4a32bc"
 
     [[cmip_model_rmse.download]]
-    sha256 = "b019d40510cebc678899a74d2cf14e33aa60452805478b2bf7176b891012aa97"
+    sha256 = "3e8fa41df226dda9d375f8cb9dbeee3e10f9fceabcad2c7b91c9633b489b0437"
     url = "https://caltech.box.com/shared/static/lmzvnjkxctlb0fanieeqxll0vdrbei9e.gz"

--- a/cmip_model_rmse/create_artifact.jl
+++ b/cmip_model_rmse/create_artifact.jl
@@ -9,7 +9,7 @@ nvars = 3
 file_urls = [
     "https://caltech.box.com/shared/static/mcqusd1t9x8sw2kukhv9m1udc2nulmna.hdf5",
     "https://caltech.box.com/shared/static/f5ornm3pogihk7kziy7825h4emoszf1w.hdf5",
-    "https://caltech.box.com/shared/static/mcqusd1t9x8sw2kukhv9m1udc2nulmna.hdf5",
+    "https://caltech.box.com/shared/static/e3h6zukujlvu7mem7i79058c5o1gnkrt.hdf5",
 ]
 
 file_paths = [


### PR DESCRIPTION
<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

Checklist:
- [ ] I created a new folder `$artifact_name`
  - [ ] I added a `README.md` in that that folder that
    - [ ] describes the data and processing done to it
    - [ ] lists the sources of the raw data
    - [ ] lists the required citation, licenses
  - [ ] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [ ] I added the scripts that retrieve, process, and produce the artifact
  - [ ] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [ ] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [ ] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [ ] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [ ] I added a link to the main `README.md` to point to the new artifact

