### PR TITLE
update to include new site data in meta data file

### DIFF
--- a/snowmip/OutputArtifacts.toml
+++ b/snowmip/OutputArtifacts.toml
@@ -1,6 +1,6 @@
 [snowmip]
-git-tree-sha1 = "da5999b8dacf81acebd7ad5ac88dd3aa847de5cb"
+git-tree-sha1 = "230f00823299e7e33d276d9b57cba985fc04eaae"
 
     [[snowmip.download]]
-    sha256 = "f1ad75041519cac56a6efa032445b91a8f52ffc0397663e538f88d6c06b57f43"
+    sha256 = "598b525c7421fabf06de4c8d4d7e05d50b7655ad2387d98c4335e90fd5633d61"
     url = "https://caltech.box.com/shared/static/0vqhet1hsj36sgmy0ajrcrb24cihcfd7.gz"

--- a/snowmip/create_artifacts.jl
+++ b/snowmip/create_artifacts.jl
@@ -28,7 +28,9 @@ site_lat = ["lat", 45.29,  54.05, 54.650000, 54.530000 , 43.186000, 43.060000,37
 site_lon = ["lon", 5.7669,-106.3333,-105.200000,-116.783000,-116.783000, 141.328600,-107.726280, 26.590000,-107.711320, 9.807]
 site_elev = ["elevation", 1325, 601, 629, 579, 2043, 17, 3714, 179, 3371, 2536]
 site_class = ["class", "alpine", "boreal", "boreal", "boreal", "alpine", "maritime", "alpine", "artic", "alpine", "alpine"]
-site_data = hcat(site_name, site_lat, site_lon, site_elev, site_class)
+site_year_start = ["year_start",1994,1997,1997,1997,1988,2005,2005,2007,2005,1996]
+site_year_end = ["year_end",2014,2010,2010,2010,2008,2015,2015,2014,2015,2016]
+site_data = hcat(site_name, site_lat, site_lon, site_elev, site_class, site_year_start, site_year_end)
 
 open(joinpath(outputdir, "site_metadata.txt"), "w") do io
     writedlm(io, site_data)


### PR DESCRIPTION
Updates the snowmip artifact so that the metadata includes the start and end dates of the data.

Checklist:
- [N/A] I created a new folder `$artifact_name`
  - [N/A] I added a `README.md` in that that folder that
    - [N/A] describes the data and processing done to it
    - [N/A] lists the sources of the raw data
    - [N/A] lists the required citation, licenses
  - [N/A] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [X] I added the scripts that retrieve, process, and produce the artifact
  - [X] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [X] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [X] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [X] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [N/A] I added a link to the main `README.md` to point to the new artifact

