### PR TITLE
update radiation observation

### DIFF
--- a/ClimaArtifactsHelper.jl/src/ClimaArtifactsHelper.jl
+++ b/ClimaArtifactsHelper.jl/src/ClimaArtifactsHelper.jl
@@ -175,7 +175,6 @@ function create_artifact_guided_one_file(
     artifact_name,
     file_url = nothing,
 )
-
     output_dir = artifact_name
 
     if isdir(output_dir)
@@ -191,6 +190,8 @@ function create_artifact_guided_one_file(
         downloaded_file = download(file_url)
         Base.mv(downloaded_file, file_path)
     end
+
+    Base.cp(file_path, joinpath(output_dir, basename(file_path)))
 
     create_artifact_guided(output_dir; artifact_name)
 end

--- a/radiation_obs/Manifest.toml
+++ b/radiation_obs/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.2"
+julia_version = "1.10.4"
 manifest_format = "2.0"
-project_hash = "74753091693fecdd4a33be59e19da0ff479810d2"
+project_hash = "9a4e7ac562fe186ebf499628f8f8dbe3040cf9bc"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
@@ -21,27 +21,27 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[deps.BitFlags]]
-git-tree-sha1 = "2dc09997850d68179b69dafb58ae806167a32b1b"
+git-tree-sha1 = "0691e34b3bb8be9307330f88d1a3c3f25466c24d"
 uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
-version = "0.1.8"
+version = "0.1.9"
 
 [[deps.ClimaArtifactsHelper]]
-deps = ["ArtifactUtils", "Pkg", "REPL", "SHA"]
+deps = ["ArtifactUtils", "Downloads", "Pkg", "REPL", "SHA"]
 path = "../ClimaArtifactsHelper.jl"
 uuid = "6ffa2572-8378-4377-82eb-ea11db28b255"
 version = "0.0.1"
 
 [[deps.CodecZlib]]
 deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "59939d8a997469ee05c4b4944560a820f9ba0d73"
+git-tree-sha1 = "bce6804e5e6044c6daab27bb533d1295e4a2e759"
 uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.4"
+version = "0.7.6"
 
 [[deps.ConcurrentUtilities]]
 deps = ["Serialization", "Sockets"]
-git-tree-sha1 = "6cbbd4d241d7e6579ab354737f4dd95ca43946e1"
+git-tree-sha1 = "ea32b83ca4fefa1768dc84e504cc0a94fb1ab8d1"
 uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
-version = "2.4.1"
+version = "2.4.2"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -91,9 +91,9 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
-git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
+git-tree-sha1 = "f389674c99bfcde17dc57454011aa44d5a260a40"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.5.0"
+version = "1.6.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -168,9 +168,9 @@ version = "1.4.3"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "a028ee3cb5641cccc4c24e90c36b0a4f7707bdf5"
+git-tree-sha1 = "1b35263570443fdd9e76c76b7062116e2f374ab8"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "3.0.14+0"
+version = "3.0.15+0"
 
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -236,13 +236,9 @@ deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[deps.TranscodingStreams]]
-git-tree-sha1 = "a947ea21087caba0a798c5e494d0bb78e3a1a3a0"
+git-tree-sha1 = "e84b3a11b9bece70d14cce63406bbc79ed3464d2"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.10.9"
-weakdeps = ["Random", "Test"]
-
-    [deps.TranscodingStreams.extensions]
-    TestExt = ["Test", "Random"]
+version = "0.11.2"
 
 [[deps.URIs]]
 git-tree-sha1 = "67db6cc7b3821e19ebe75791a9dd19c9b1188f2b"

--- a/radiation_obs/OutputArtifacts.toml
+++ b/radiation_obs/OutputArtifacts.toml
@@ -1,6 +1,2 @@
 [radiation_obs]
-git-tree-sha1 = "c9eef049fc3bf057f35332c316755a694b0eb5ef"
-
-    [[radiation_obs.download]]
-    sha256 = "3274926803246cd3738e2d9f36c3fc2652fdb564fba80ddcb10860fd5d8cb552"
-    url = "https://caltech.box.com/shared/static/odvaz76hi3ujakhwgkilzbitk49ty1fw.gz"
+git-tree-sha1 = "945e31f8028a581f7e8435cb691462124484567a"

--- a/radiation_obs/Project.toml
+++ b/radiation_obs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 ClimaArtifactsHelper = "6ffa2572-8378-4377-82eb-ea11db28b255"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/radiation_obs/README.md
+++ b/radiation_obs/README.md
@@ -1,9 +1,10 @@
 # Radiative fluxes data from CERES
 
-This artifact contains monthly mean top-of-the-atmosphere radiative fluxes from the 
-Clouds and Earth's Radiant Energy Systems (CERES) Energy Balanced and Filled (EBAF) from March 2000 to March 2023. 
+This artifact contains monthly mean top-of-the-atmosphere and surface radiative fluxes from the 
+Clouds and Earth's Radiant Energy Systems (CERES) Energy Balanced and Filled (EBAF) from March 2000 to October 2019. 
 The data includes incoming solar flux, upward shortwave and longwave radiative fluxes, and net radiative fluxes
-for all-sky and clear-sky conditions. The net radiative fluxes is positive downward. All fluxes are in W m-2.
-The data can be downloaded from the data repository [Will and Schneider 2024](https://data.caltech.edu/records/z24s9-nqc90).
+for all-sky and clear-sky conditions. The net radiative fluxes is positive downward. The resolution is 1 deg x 1 deg.
+All fluxes are in W m-2. The data was downloaded from [CERES website](https://ceres.larc.nasa.gov/data/) 
+in September 2024.
 
-License: Creative Commons Attribution 4.0 International
+License: Creative Commons Zero

--- a/radiation_obs/create_artifact.jl
+++ b/radiation_obs/create_artifact.jl
@@ -2,25 +2,7 @@ using Downloads
 
 using ClimaArtifactsHelper
 
-# This file is in a zip file on caltech data archive: 
-# https://data.caltech.edu/records/z24s9-nqc90/files/Climate_Model_RMSE_Analysis.zip?download=1
-const FILE_URL = "https://caltech.box.com/shared/static/hd5emjq0ryzn1kdqddfwhoieqrc2pcpj.nc"
-const FILE_PATH = "CERES_EBAF-TOA_Ed4.2_Subset_200003-202303.g025.nc"
+const FILE_URL = "https://caltech.box.com/shared/static/j0kxdt9nxnk915burnwqs622ots2ylgv.nc"
+const FILE_PATH = "CERES_EBAF_Ed4.2_Subset_200003-201910.nc"
 
-output_dir = "radiation_obs_artifact"
-if isdir(output_dir)
-    @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
-    @warn "Abort this calculation, unless you know what you are doing."
-else
-    mkdir(output_dir)
-end
-
-if !isfile(FILE_PATH)
-    @info "$FILE_PATH not found, downloading it (might take a while)"
-    precipitation_obs_file = Downloads.download(FILE_URL)
-    Base.mv(precipitation_obs_file, FILE_PATH)
-    Base.cp(FILE_PATH, joinpath(output_dir, basename(FILE_PATH)))
-end
-
-@info "Data file generated!"
-create_artifact_guided(output_dir; artifact_name = basename(@__DIR__))
+create_artifact_guided_one_file(FILE_PATH; artifact_name = basename(@__DIR__), file_url = FILE_URL)


### PR DESCRIPTION
<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->
Update the radiation observation artifact to include surface radiative fluxes. The artifact is also much bigger and not downloadable now because of higher resolution. Also fixes create_artifact_guided_one_file.

Checklist:
- [ ] I created a new folder `$artifact_name`
  - [ ] I added a `README.md` in that that folder that
    - [ ] describes the data and processing done to it
    - [ ] lists the sources of the raw data
    - [ ] lists the required citation, licenses
  - [ ] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [ ] I added the scripts that retrieve, process, and produce the artifact
  - [ ] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [x] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [x] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [x] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [ ] I added a link to the main `README.md` to point to the new artifact

