### PR TITLE
Add append option to create_artifact_guided

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ S. Gupta et al 2022, 2024](https://github.com/CliMA/ClimaArtifacts/tree/main/soi
 
 # The ultimate guide to ClimaArtifacts
 
-Last update: 25 August 2024
+Last update: 26 September 2024
 
 #### What is an artifact?
 
@@ -202,6 +202,10 @@ To create a new artifact in `ClimaArtifacts`:
    artifact_name = basename(@__DIR__))`
 5. The `create_artifact_guided` starts a guided process that gives you the
    string to put in your `Artifacts.toml` files.
+
+If you are creating multiple artifacts from the same file, consider adding
+`append = true` to ensure that the `OutputArtifacts.toml` has all the
+information.
    
 If your artifact is tied to your particular module, you may elect to add it to
 your repository instead. To do so, follow the same steps above with the

--- a/aerosol_concentrations/create_artifact.jl
+++ b/aerosol_concentrations/create_artifact.jl
@@ -203,4 +203,5 @@ create_aerosol(
 create_artifact_guided(
     output_dir_lowres;
     artifact_name = basename(@__DIR__) * "_lowres",
+    append = true
 )

--- a/ozone_concentrations/create_artifact.jl
+++ b/ozone_concentrations/create_artifact.jl
@@ -105,4 +105,5 @@ create_ozone(
 create_artifact_guided(
     output_dir_lowres;
     artifact_name = basename(@__DIR__) * "_lowres",
+    append = true
 )


### PR DESCRIPTION
Artifacts have started having a `lowres` version. This flag allows one `create_artifact` file to create multiple artifacts.

Closes #43 
