### PR TITLE
ETOPO2022 orography (ice-surface) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ S. Gupta et al 2022, 2024](https://github.com/CliMA/ClimaArtifacts/tree/main/soi
 - [Measured sea ice concentration and sea surface
   temperature](https://github.com/CliMA/ClimaArtifacts/tree/main/historical_sst_sic)
 - [Global shortwave albedo from CLM model output for coupled and standalone land models](https://github.com/CliMA/ClimaArtifacts/tree/main/cesm2_albedo)
+- [Earth orography at 30 and 60 arc-second resolutions](https:////github.com/CliMA/ClimaArtifacts/tree/main/earth_orography)
 
 # The ultimate guide to ClimaArtifacts
 

--- a/earth_orography/OutputArtifacts.toml
+++ b/earth_orography/OutputArtifacts.toml
@@ -1,6 +1,8 @@
-[earth_orography]
-git-tree-sha1 = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+[earth_orography_30arcseconds]
+git-tree-sha1 = "03dd08fcbf363ed055a176dd7adefb60ff1c3493"
+[earth_orography_60arcseconds]
+git-tree-sha1 = "fe19d8dbe7a18ff39588e1f718014b0479d9c0f7"
 
-    [[earth_orography.download]]
-    sha256 = "533478a67c97f6d0e05549129db750f961c8fcb26b00cd14e4746c44a1af0c92"
-    url = "https://caltech.box.com/shared/static/x9uijilyrtxo93w9irjx7xlgo53vz9hs.gz"
+    [[earth_orography_60arcseconds.download]]
+    sha256 = "eca66c0701d1c2b9e271742314915ffbf4a0fae92709df611c323f38e019966e"
+    url = "https://caltech.box.com/shared/static/4asrxcgl6xsgenfcug9p0wkkyhtqilgk.gz"

--- a/earth_orography/OutputArtifacts.toml
+++ b/earth_orography/OutputArtifacts.toml
@@ -1,0 +1,6 @@
+[earth_orography]
+git-tree-sha1 = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+    [[earth_orography.download]]
+    sha256 = "533478a67c97f6d0e05549129db750f961c8fcb26b00cd14e4746c44a1af0c92"
+    url = "https://caltech.box.com/shared/static/x9uijilyrtxo93w9irjx7xlgo53vz9hs.gz"

--- a/earth_orography/Project.toml
+++ b/earth_orography/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+ClimaArtifactsHelper = "6ffa2572-8378-4377-82eb-ea11db28b255"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"

--- a/earth_orography/README.md
+++ b/earth_orography/README.md
@@ -1,0 +1,34 @@
+# Earth orography (ETOPO2022 Dataset)
+
+
+## Overview 
+
+This artifact provides the 30 and 60 arc-second ice-surface orography information 
+in NetCDF format. 
+- ETOPO_2022_v1_30s_N90W180_surface.nc (30 arc-second, ice surface, 1.5GB)
+- ETOPO_2022_v1_60s_N90W180_surface.nc (60 arc-second, ice surface, 456MB)
+These artifacts are intended for use with the `ClimaUtilities.SpaceVaryingInputs`
+tools to regrid earth's orography onto `ClimaCore` cubed-sphere grids. 
+
+
+A user guide and additional information for the ETOPO2022 dataset is available here: 
+- https://www.ncei.noaa.gov/products/etopo-global-relief-model
+- https://www.ngdc.noaa.gov/mgg/global/relief/ETOPO2022/docs/1.2%20ETOPO%202022%20User%20Guide.pdf
+
+## Usage
+
+To recreate the artifact, start a Julia session and activate the 
+`earth_orography` project. Then, run the `create_artifact.jl` file. 
+e.g. 
+```
+(earth_orography) pkg>
+julia> include("create_artifact.jl")
+```
+
+## References
+
+NOAA National Centers for Environmental Information. 2022: ETOPO 2022 15 Arc-Second
+Global Relief Model. NOAA National Centers for Environmental Information.
+https://doi.org/10.25921/fd45-gt74 . Accessed 10/7/2024.
+
+

--- a/earth_orography/create_artifact.jl
+++ b/earth_orography/create_artifact.jl
@@ -1,43 +1,67 @@
 using Downloads
 using ClimaArtifactsHelper
 
-const FILE_URLS = [
-"https://www.ngdc.noaa.gov/thredds/fileServer/global/ETOPO2022/30s/30s_surface_elev_netcdf/ETOPO_2022_v1_30s_N90W180_surface.nc",
-"https://www.ngdc.noaa.gov/thredds/fileServer/global/ETOPO2022/60s/60s_surface_elev_netcdf/ETOPO_2022_v1_60s_N90W180_surface.nc",
-]
+const FILE_URL_30ARCSEC = "https://www.ngdc.noaa.gov/thredds/fileServer/global/ETOPO2022/30s/30s_surface_elev_netcdf/ETOPO_2022_v1_30s_N90W180_surface.nc"
+const FILE_URL_60ARCSEC = "https://www.ngdc.noaa.gov/thredds/fileServer/global/ETOPO2022/60s/60s_surface_elev_netcdf/ETOPO_2022_v1_60s_N90W180_surface.nc"
 
-const FILE_PATHS = [
-"ETOPO_2022_v1_30s_N90W180_surface.nc",
-"ETOPO_2022_v1_60s_N90W180_surface.nc",
-]
+const FILE_PATH_30ARCSEC = "ETOPO_2022_v1_30s_N90W180_surface.nc"
+const FILE_PATH_60ARCSEC = "ETOPO_2022_v1_60s_N90W180_surface.nc"
 
-output_dir = basename(@__DIR__) * "_artifact"
-if isdir(output_dir)
+output_dir_30arcsec =  "earth_orography_30arcsec"*"_artifact"
+output_dir_60arcsec =  "earth_orography_60arcsec"*"_artifact"
+
+if isdir(output_dir_30arcsec)
     @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
     @warn "Abort this calculation, unless you know what you are doing."
 else
-    mkdir(output_dir)
+    mkdir(output_dir_30arcsec)
 end
 
-for (file_path, file_url) in zip(FILE_PATHS, FILE_URLS)
-    println(file_url)
-    println(file_path)
-    if !isfile(file_path)
-        @info "$file_path not found, downloading it (might take a while)"
-        # The server has poor certificates, so we have to disable verification
-        downloader = Downloads.Downloader()
-        downloader.easy_hook =
-            (easy, info) -> Downloads.Curl.setopt(
-                easy,
-                Downloads.Curl.CURLOPT_SSL_VERIFYPEER,
-                false,
-            )
-        println(file_url)
-        println(file_path)
-        downloaded_file = Downloads.download(file_url; downloader)
-        Base.mv(downloaded_file, file_path)
-    end
+# 30 ARC SECOND DATA
+path = FILE_PATH_30ARCSEC
+url = FILE_URL_30ARCSEC
+downloader = Downloads.Downloader()
+downloader.easy_hook =
+    (easy, info) -> Downloads.Curl.setopt(
+        easy,
+        Downloads.Curl.CURLOPT_SSL_VERIFYPEER,
+        false,
+    )
+if !isfile(path)
+    @info "$path not found, downloading it (might take a while)"
+    downloaded_file = Downloads.download(url)
+    Base.mv(downloaded_file, path)
 end
+Base.cp(path, joinpath(output_dir_30arcsec, basename(path)))
+create_artifact_guided(output_dir_30arcsec; artifact_name = basename(@__DIR__) * "_30arcseconds")
+
+if isdir(output_dir_60arcsec)
+    @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
+    @warn "Abort this calculation, unless you know what you are doing."
+else
+    mkdir(output_dir_60arcsec)
+end
+
+# 60 ARC SECOND DATA
+path = FILE_PATH_60ARCSEC
+url = FILE_URL_60ARCSEC
+downloader = Downloads.Downloader()
+downloader.easy_hook =
+    (easy, info) -> Downloads.Curl.setopt(
+        easy,
+        Downloads.Curl.CURLOPT_SSL_VERIFYPEER,
+        false,
+    )
+if !isfile(path)
+    @info "$path not found, downloading it (might take a while)"
+    downloaded_file = Downloads.download(url)
+    Base.mv(downloaded_file, path)
+end
+Base.cp(path, joinpath(output_dir_60arcsec, basename(path)))
+create_artifact_guided(output_dir_60arcsec; artifact_name = basename(@__DIR__) * "_60arcseconds", append = true)
 
 @info "Generated earth orography files"
-create_artifact_guided(output_dir; artifact_name = basename(@__DIR__))
+
+
+
+

--- a/earth_orography/create_artifact.jl
+++ b/earth_orography/create_artifact.jl
@@ -1,0 +1,43 @@
+using Downloads
+using ClimaArtifactsHelper
+
+const FILE_URLS = [
+"https://www.ngdc.noaa.gov/thredds/fileServer/global/ETOPO2022/30s/30s_surface_elev_netcdf/ETOPO_2022_v1_30s_N90W180_surface.nc",
+"https://www.ngdc.noaa.gov/thredds/fileServer/global/ETOPO2022/60s/60s_surface_elev_netcdf/ETOPO_2022_v1_60s_N90W180_surface.nc",
+]
+
+const FILE_PATHS = [
+"ETOPO_2022_v1_30s_N90W180_surface.nc",
+"ETOPO_2022_v1_60s_N90W180_surface.nc",
+]
+
+output_dir = basename(@__DIR__) * "_artifact"
+if isdir(output_dir)
+    @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
+    @warn "Abort this calculation, unless you know what you are doing."
+else
+    mkdir(output_dir)
+end
+
+for (file_path, file_url) in zip(FILE_PATHS, FILE_URLS)
+    println(file_url)
+    println(file_path)
+    if !isfile(file_path)
+        @info "$file_path not found, downloading it (might take a while)"
+        # The server has poor certificates, so we have to disable verification
+        downloader = Downloads.Downloader()
+        downloader.easy_hook =
+            (easy, info) -> Downloads.Curl.setopt(
+                easy,
+                Downloads.Curl.CURLOPT_SSL_VERIFYPEER,
+                false,
+            )
+        println(file_url)
+        println(file_path)
+        downloaded_file = Downloads.download(file_url; downloader)
+        Base.mv(downloaded_file, file_path)
+    end
+end
+
+@info "Generated earth orography files"
+create_artifact_guided(output_dir; artifact_name = basename(@__DIR__))


### PR DESCRIPTION
Current access to topography artifacts in our repositories is restricted to downsampled ETOPO1 (deprecated) data. This artifact addition introduces the ETOPO2022 dataset for use with the ClimaUtilities SpaceVaryingInputs regridding tools. 

Checklist:
- [x] I created a new folder `$artifact_name`
  - [x] I added a `README.md` in that that folder that
    - [x] describes the data and processing done to it
    - [x] lists the sources of the raw data
    - [x] lists the required citation, licenses
  - [ ] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [x] I added the scripts that retrieve, process, and produce the artifact
  - [x] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [x] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [x] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [x] I added the relevant code to the `Overrides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [x] I added a link to the main `README.md` to point to the new artifact

