### PR TITLE
Add global foliage clumping index data derived from MODIS

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ S. Gupta et al 2022, 2024](https://github.com/CliMA/ClimaArtifacts/tree/main/soi
 - [Global shortwave albedo from CLM model output for coupled and standalone land models](https://github.com/CliMA/ClimaArtifacts/tree/main/cesm2_albedo)
 - [Earth orography at 30 and 60 arc-second resolutions](https:////github.com/CliMA/ClimaArtifacts/tree/main/earth_orography)
 - [Monthly Mean CO2 from Mauna Loa](https://github.com/CliMA/ClimaArtifacts/tree/main/co2_dataset)
+- [Foliage clumping index, derived from MODIS data for 2006](https:////github.com/CliMA/ClimaArtifacts/tree/main/modis_clumping_index)
 
 # The ultimate guide to ClimaArtifacts
 
@@ -244,7 +245,7 @@ just uploaded.
 
 Go to [Caltech Box](https://caltech.app.box.com/). Navigate to your favorite
 folder and upload your data. Once the data is uploaded, you have to make it
-sherable. Click on the sharing icon on the right, the following screen will pop
+shareable. Click on the sharing icon on the right, the following screen will pop
 up:
 
 ![screenshot1](./screenshots/screenshot1.png)

--- a/modis_clumping_index/OutputArtifacts.toml
+++ b/modis_clumping_index/OutputArtifacts.toml
@@ -1,0 +1,6 @@
+[modis_clumping_index]
+git-tree-sha1 = "b849eb95c09190095e7bf021494ddeda8858af01"
+
+    [[modis_clumping_index.download]]
+    sha256 = "e4c766a93a673e5dc22540687ef5616416d65bb13a0f4a67789b95d49ccbb158"
+    url = "https://caltech.box.com/shared/static/ec2y3k5kqpl9wjvtsx3584wgkp5q8dyw.gz"

--- a/modis_clumping_index/Project.toml
+++ b/modis_clumping_index/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+ClimaArtifactsHelper = "6ffa2572-8378-4377-82eb-ea11db28b255"
+GriddingMachine = "f20cf718-bf4d-4727-bc8f-485b1f283ac6"
+NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"

--- a/modis_clumping_index/README.md
+++ b/modis_clumping_index/README.md
@@ -1,0 +1,14 @@
+# Foliage clumping index, derived from MODIS data for 2006
+
+This artifact repackages data coming from:
+He, L., J.M. Chen, J. Pisek, C. Schaaf, and A.H. Strahler. 2017.  Global 500-m Foliage Clumping Index Data Derived from MODIS BRDF, 2006. ORNL DAAC, Oak Ridge, Tennessee, USA. [DOI](https://doi.org/10.3334/ORNLDAAC/1531)
+
+The data is fetched in NetCDF format and reprojected to WGS84 via the GriddingMachine.jl package:
+Y. Wang, P. Köhler, R. K. Braghiere, M. Longo, R. Doughty, A. A. Bloom, and C. Frankenberg. 2022. GriddingMachine, a database and software for Earth system modeling at global and regional scales. Scientific Data. 9: 258. [DOI](https://doi.org/10.1038/s41597-022-01346-x)
+
+We regrid the data to 1 degree resolution, and output a netCDF file with the following variables:
+  - `ci`: Foliage clumping index, unitless
+  - `lat`: Latitude, degrees north
+  - `lon`: Longitude, degrees east
+
+License: Creative Commons Zero

--- a/modis_clumping_index/create_artifacts.jl
+++ b/modis_clumping_index/create_artifacts.jl
@@ -1,0 +1,107 @@
+# Global clumping index data derived from MODIS data by
+# He, L., J.M. Chen, J. Pisek, C. Schaaf, and A.H. Strahler. 2017. 
+# Global 500-m Foliage Clumping Index Data Derived from MODIS BRDF, 2006.
+# ORNL DAAC, Oak Ridge, Tennessee, USA. https://doi.org/10.3334/ORNLDAAC/1531
+
+# We will use GriddingMachine.jl to fetch and process the MODIS CI data into the
+# desired format for consumption by the Land model:
+# Y. Wang, P. Köhler, R. K. Braghiere, M. Longo, R. Doughty, A. A. Bloom, and
+# C. Frankenberg. 2022. GriddingMachine, a database and software for Earth
+# system modeling at global and regional scales. Scientific Data. 9: 258
+# https://doi.org/10.1038/s41597-022-01346-x
+
+################################################################################
+# IMPORTS                                                                      #
+################################################################################
+
+using NCDatasets
+
+using GriddingMachine.Collector
+using GriddingMachine.Indexer
+using GriddingMachine.Blender
+
+using ClimaArtifactsHelper
+
+################################################################################
+# CONSTANTS                                                                    #
+################################################################################
+
+# Dataset name to be fetched via the GriddingMachine
+MODIS_CI_DATASET = "2X_1Y_V1"
+
+# Output directory
+OUTPUT_DIR = "modis_clumping_index"
+
+# Output nc file name
+OUTPUT_FILE = "He_et_al_2012_1x1.nc"
+
+# Resolution of the simulation
+RESOLUTION = 1
+
+################################################################################
+# MAIN                                                                         #
+################################################################################
+
+if isdir(OUTPUT_DIR)
+    @warn "$OUTPUT_DIR already exists. Content will end up in the artifact and
+           may be overwritten."
+    @warn "Abort this calculation, unless you know what you are doing."
+else
+    mkdir(OUTPUT_DIR)
+end
+
+# Download the CI data as a julia artifact.
+ci_collector  = Collector.clumping_index_collection()
+download_path = Collector.query_collection(ci_collector, MODIS_CI_DATASET)
+
+# Read the data from the dowloaded nc file
+ci_data = Indexer.read_LUT(download_path)
+
+# Regrid the data to the desired simulation resolution - 1x1 degree. Note that 
+# the regridder will require integer trucation of the divider (1/R)
+ci_data_regridded = Blender.regrid(ci_data[1], Int64(1 / RESOLUTION))
+
+# Get the original the lat/lon vectors of the dataset so that we may compute the
+# lat/lon of the regridded data.
+orig_data = NCDataset(download_path, "r")
+orig_lat = orig_data["lat"][:]
+orig_lon = orig_data["lon"][:]
+close(orig_data)
+
+# Since we regridded to half of the resolution of the original data, we need to 
+# average every 2 lat/lon points to get the lat/lon of the regridded data.
+out_lon = (orig_lon[1:2:end] .+ orig_lon[2:2:end]) ./ 2
+out_lat = (orig_lat[1:2:end] .+ orig_lat[2:2:end]) ./ 2
+
+# Write the regridded data to the output directory
+output_path = joinpath(OUTPUT_DIR, OUTPUT_FILE)
+ds          = NCDataset(output_path, "c")
+
+# Define the dimensions of the data -> 2D spatially varying data
+defDim(ds, "lon", size(ci_data_regridded)[1])
+defDim(ds, "lat", size(ci_data_regridded)[2])
+
+# Define the variables of the data - lat, lon, and the clumping index
+la     = defVar(ds, "lat", Float32, ("lat",))
+lo     = defVar(ds, "lon", Float32, ("lon",))
+ci_var = defVar(ds, "ci", Float32, ("lon", "lat"))
+
+# Set the attributes of the variables. Clumping index is unitless.
+la.attrib["units"]             = "degrees_north"
+la.attrib["standard_name"]     = "latitude"
+lo.attrib["units"]             = "degrees_east"
+lo.attrib["standard_name"]     = "longitude"
+ci_var.attrib["units"]         = "unitless"
+ci_var.attrib["standard_name"] = "Foliage Clumping Index"
+
+# Write the data for each variable out to the nc file
+la[:]     = out_lat
+lo[:]     = out_lon
+ci_var[:, :] = ci_data_regridded
+close(ds)
+
+# Remove the initial downloaded artifact file - desired data is now stored in 
+# the CliMA artifact.
+Collector.clean_collections!(ci_collector)
+
+create_artifact_guided(OUTPUT_DIR; artifact_name = basename(@__DIR__))


### PR DESCRIPTION
<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

This PR adds a new artifact for global clumping index, used by ClimaLand. 

The corresponding changes in ClimaLand are found [here](https://github.com/CliMA/ClimaLand.jl/pull/863)

Checklist:
- [x] I created a new folder `$artifact_name`
  - [x] I added a `README.md` in that that folder that
    - [x] describes the data and processing done to it
    - [x] lists the sources of the raw data
    - [x] lists the required citation, licenses
  - [x] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [x] I added the scripts that retrieve, process, and produce the artifact
  - [x] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [x] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [x] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [x] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [x] I added a link to the main `README.md` to point to the new artifact

