### PR TITLE
Update precipitation_obs artifact data and readme

### DIFF
--- a/precipitation_obs/Manifest.toml
+++ b/precipitation_obs/Manifest.toml
@@ -26,7 +26,7 @@ uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
 version = "0.1.8"
 
 [[deps.ClimaArtifactsHelper]]
-deps = ["ArtifactUtils", "Pkg", "REPL", "SHA"]
+deps = ["ArtifactUtils", "Downloads", "Pkg", "REPL", "SHA"]
 path = "../ClimaArtifactsHelper.jl"
 uuid = "6ffa2572-8378-4377-82eb-ea11db28b255"
 version = "0.0.1"

--- a/precipitation_obs/OutputArtifacts.toml
+++ b/precipitation_obs/OutputArtifacts.toml
@@ -1,6 +1,6 @@
 [precipitation_obs]
-git-tree-sha1 = "7486bf32e9352493f69364aead26f01eaf90d2af"
+git-tree-sha1 = "5f0075f042bc83b580d2c4f725f851d8e0b9c20a"
 
     [[precipitation_obs.download]]
-    sha256 = "463ebc1886c4e0be9656656da699f2cbb87d7c2568d5e81277c0c8a415dc8143"
-    url = "https://caltech.box.com/shared/static/j63uak557kw7tlzb3dgwifoaeczekzm4.gz"
+    sha256 = "22d0ff92a6fe4c5c9b26af89b98a6c175497e8dd028bb15eb4c4ae6e9712287b"
+    url = "https://caltech.box.com/shared/static/j1x56khvit9sutq8lapdqxngpwd465l4.gz"

--- a/precipitation_obs/OutputArtifacts.toml
+++ b/precipitation_obs/OutputArtifacts.toml
@@ -2,5 +2,5 @@
 git-tree-sha1 = "5f0075f042bc83b580d2c4f725f851d8e0b9c20a"
 
     [[precipitation_obs.download]]
-    sha256 = "22d0ff92a6fe4c5c9b26af89b98a6c175497e8dd028bb15eb4c4ae6e9712287b"
-    url = "https://caltech.box.com/shared/static/j1x56khvit9sutq8lapdqxngpwd465l4.gz"
+    sha256 = "1aea361ee1c2636bd5c4cc343202dab814d246a7e0356a9caac9fd9c7cf3821c"
+    url = "https://caltech.box.com/shared/static/j63uak557kw7tlzb3dgwifoaeczekzm4.gz"

--- a/precipitation_obs/README.md
+++ b/precipitation_obs/README.md
@@ -1,7 +1,64 @@
 # Precipitation data from GPCP
 
-This artifact contains monthly mean precipitation from the Global Precipitation Climatology Project (GPCP) 
-from January 1979 to May 2023. The data can be downloaded from the 
-data repository [Will and Schneider 2024](https://data.caltech.edu/records/z24s9-nqc90).
+This artifact contains monthly mean precipitation from the Global Precipitation Climatology Project (GPCP)
+from January 1979 to September 2024. A current version of data, with data from January 1979 to the present
+can be downloaded from the
+NOAA: [GPCP Monthly Analysis Product](https://psl.noaa.gov/data/gridded/data.gpcp.html).
 
-License: Creative Commons Attribution 4.0 International
+## Usage
+
+To recreate the artifact:
+
+Run `julia --project create_artifact.jl`
+
+## Data Specifications
+
+### Temporal Coverage
+
+- Monthly values 1979/01 through 2024/09
+
+### Spatial Coverage
+
+- 88.75N - 88.75S, 1.25E - 358.75E,
+- 2.5 degree latitude x 2.5 degree longitude global grid (144x72)
+
+### Caveats
+
+- The last 2 months are interim data. Interim data covers 2024/08 through latest
+
+### Files
+
+- This artifact contains one file, `precip.mon.mean.nc`, which is 20MB and contains the `precip` variable
+
+### Description
+
+The following description is taken directly from the [NOAA](https://psl.noaa.gov/data/gridded/data.gpcp.html):
+
+The GPCP Monthly product provides a consistent analysis of global precipitation from an
+integration of various satellite data sets over land and ocean and a gauge analysis over land.
+Data from rain gauge stations, satellites, and sounding observations have been merged to estimate
+monthly rainfall on a 2.5-degree global grid from 1979 to the present. The careful combination
+of satellite-based rainfall estimates provides the most complete analysis of rainfall available
+to date over the global oceans, and adds necessary spatial detail to the rainfall analyses over land.
+
+### Variables
+
+#### precip
+
+- **long_name**: Average Monthly Rate of Precipitation
+- **Dimensions**: lon × lat × time
+- **Datatype**: Union{Missing, Float32}
+- **units**: mm/day
+
+## Citations and Usage Restrictions
+
+This data is in the public domain and may be used freely, as long as you do not claim it as
+your own, use in it a manner that implies affiliation with NOAA, or modify it and present it
+as official government data. The NOAA also requests that they be acknowledged when the data
+is used in documents or publications using this data.
+
+### Citation
+
+Adler, R.F., G.J. Huffman, A. Chang, R. Ferraro, P. Xie, J. Janowiak, B. Rudolf, U. Schneider,
+S. Curtis, D. Bolvin, A. Gruber, J. Susskind, and P. Arkin,
+2003: The Version 2 Global Precipitation Climatology Project (GPCP) Monthly Precipitation Analysis (1979-Present). J. Hydrometeor., 4,1147-1167.

--- a/precipitation_obs/README.md
+++ b/precipitation_obs/README.md
@@ -20,7 +20,7 @@ Run `julia --project create_artifact.jl`
 ### Spatial Coverage
 
 - 88.75N - 88.75S, 1.25E - 358.75E,
-- 2.5 degree latitude x 2.5 degree longitude global grid (144x72)
+- 2.5 degree latitude x 2.5 degree longitude global grid
 
 ### Caveats
 

--- a/precipitation_obs/create_artifact.jl
+++ b/precipitation_obs/create_artifact.jl
@@ -5,7 +5,7 @@ using ClimaArtifactsHelper
 const FILE_URL = "https://downloads.psl.noaa.gov/Datasets/gpcp/precip.mon.mean.nc"
 const FILE_PATH = "precip.mon.mean.nc"
 
-output_dir = "precipitation_obs_artifact_v2"
+output_dir = "precipitation_obs_artifact"
 if isdir(output_dir)
     @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
     @warn "Abort this calculation, unless you know what you are doing."

--- a/precipitation_obs/create_artifact.jl
+++ b/precipitation_obs/create_artifact.jl
@@ -2,12 +2,10 @@ using Downloads
 
 using ClimaArtifactsHelper
 
-# This file is in a zip file on caltech data archive: 
-# https://data.caltech.edu/records/z24s9-nqc90/files/Climate_Model_RMSE_Analysis.zip?download=1
-const FILE_URL = "https://caltech.box.com/shared/static/k1or5d0d9xdvyfiytl1os7z341monkzn.nc"
-const FILE_PATH = "gpcp.precip.mon.mean.197901-202305.nc"
+const FILE_URL = "https://downloads.psl.noaa.gov/Datasets/gpcp/precip.mon.mean.nc"
+const FILE_PATH = "precip.mon.mean.nc"
 
-output_dir = "precipitation_obs_artifact"
+output_dir = "precipitation_obs_artifact_v2"
 if isdir(output_dir)
     @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
     @warn "Abort this calculation, unless you know what you are doing."


### PR DESCRIPTION
The new data is from the NOAA rather than the files from caltech data for "Error analysis of climate models...". It contains all the same data as the old artifact, except with data for 2023-present.

The old artifact is still on box, and the new artifact has v2 appended to its name. The new data has a different file name as well.


<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

Checklist:
- [x] I created a new folder `$artifact_name`
  - [x] I added a `README.md` in that that folder that
    - [x] describes the data and processing done to it
    - [x] lists the sources of the raw data
    - [x] lists the required citation, licenses
  - [x] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [x] I added the scripts that retrieve, process, and produce the artifact
  - [x] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [x] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [x] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [x] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [x] I added a link to the main `README.md` to point to the new artifact

