### PR TITLE
add TwoStream test data artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ S. Gupta et al 2022, 2024](https://github.com/CliMA/ClimaArtifacts/tree/main/soi
 - [Foliage clumping index, derived from MODIS data for 2006](https:////github.com/CliMA/ClimaArtifacts/tree/main/modis_clumping_index)
 - [Subset of ILAMB datasets](https:////github.com/CliMA/ClimaArtifacts/tree/main/ilamb_data)
 - [Bonan 2019 Richards equation data](https:////github.com/CliMA/ClimaArtifacts/tree/main/bonan_richards_eqn)
+- [TwoStream model implementation test data](https:////github.com/CliMA/ClimaArtifacts/tree/main/twostr_test)
 
 # The ultimate guide to ClimaArtifacts
 
@@ -240,7 +241,7 @@ about your new artifact and where it is used.
 To test that your artifact works, create a new folder, e.g., `/tmp/mynewfolder`,
 create an `Artifacts.toml` file in it, the content of which has to be the
 `OutputArtifacts.toml` file created by the `create_artifact_guided` function.
-Then, call `julia --project -e 'using Artifacts; prinln(artifact"AAAAAA")'` from
+Then, call `julia --project -e 'using Artifacts; println(artifact"AAAAAA")'` from
 that folder, where `AAAAAA` is the name of your artifact. It should print
 `/groups/esm/ClimaArtifacts/artifacts/AAAAAA`, where `AAAAAA` is the folder you
 just uploaded.

--- a/twostr_test/LICENSE
+++ b/twostr_test/LICENSE
@@ -1,0 +1,282 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+

--- a/twostr_test/OutputArtifacts.toml
+++ b/twostr_test/OutputArtifacts.toml
@@ -1,0 +1,6 @@
+[twostr_test]
+git-tree-sha1 = "b0986aa28e7970a9c080461f5e52fb125cda9c3d"
+
+    [[twostr_test.download]]
+    sha256 = "c972f3ff4e041a4443c6e970021f1084a1cc176c2aeeda453f3351ef7cffa60b"
+    url = "https://caltech.box.com/shared/static/zh7wb0ar8kwg4sio64id9e6otzcsfhad.gz"

--- a/twostr_test/Project.toml
+++ b/twostr_test/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+ClimaArtifactsHelper = "6ffa2572-8378-4377-82eb-ea11db28b255"
+
+[deps]
+LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"

--- a/twostr_test/README.md
+++ b/twostr_test/README.md
@@ -1,0 +1,14 @@
+# TwoStream radiative transfer model test cases
+
+This artifact contains test cases mapping sets of input parameters to expected output values for the TwoStream radiative transfer model. The test cases are used to validate the implementation of the TwoStream model in ClimaLand.
+
+The create_artifacts script hosted here generates a csv file with test cases for the TwoStream model compared against the outputs of a previous implementation of the TwoStream model:
+
+Quaife, T. 2016: PySellersTwoStream, available at:
+https://github.com/tquaife/pySellersTwoStream.
+
+We use a fork of the repository which has been patched to work with Python 3.
+
+The code used to generate this test data is licensed under GPL 2.0; the data
+itself is generated from this code and therefore we will also license it under
+GPL 2.0.

--- a/twostr_test/create_artifacts.jl
+++ b/twostr_test/create_artifacts.jl
@@ -1,0 +1,57 @@
+# This script generates test data for the CliMALand TwoStream radiative transfer
+# model. The data is generated from an earlier TwoStream implementation,
+# PySellersTwoStream:
+# Quaife, T. 2016: PySellersTwoStream, available at:
+# https://github.com/tquaife/pySellersTwoStream.
+# We use a fork of the repository which has been patched to work with Python 3.
+
+# This package does not allow for a clumping index while the ClimaLand
+# implementation does. All other parameters used to generate the test data
+# correspond to parameters in the ClimaLand implementation. The output data
+# is a CSV file with each row corresponding to a test case. The columns are
+# the parameters: solar zenith angle, leaf area index, leaf/stem orientation
+# index, leaf reflectance, leaf transmittance, soil albedo, the number of layers
+# in the canopy, and the proportion of incident radiation which is diffuse. Then
+# there is an output column for the fraction of absorbed photosynthetically
+# active radiation (fAPAR).
+
+################################################################################
+# IMPORTS                                                                      #
+################################################################################
+
+using ClimaArtifactsHelper
+import LibGit2
+
+################################################################################
+# CONSTANTS                                                                    #
+################################################################################
+
+# Output directory
+OUTPUT_DIR = "twostr_test"
+
+# Output file name
+OUTPUT_FILE = "twostr_test.csv"
+
+# Path used to clone PySellersTwoStream repository
+PSTS_PATH = "https://github.com/Espeer5/py3SellersTwoStream"
+
+################################################################################
+# MAIN                                                                         #
+################################################################################
+
+if isdir(OUTPUT_DIR)
+    @warn "$OUTPUT_DIR already exists. Content will end up in the artifact and
+           may be overwritten."
+    @warn "Abort this calculation, unless you know what you are doing."
+else
+    mkdir(OUTPUT_DIR)
+end
+
+# First, git clone the PySellersTwoStream repository from the PSTS_PATH
+isdir("py3SellersTwoStream") || LibGit2.clone(PSTS_PATH, "py3SellersTwoStream")
+
+# Next, run the python script that generates the output test data
+run(`python3 gen_2str_data.py $OUTPUT_DIR/$OUTPUT_FILE`)
+
+# Now, use guided artifact creation to create the artifact
+create_artifact_guided(OUTPUT_DIR; artifact_name = basename(@__DIR__))

--- a/twostr_test/gen_2str_data.py
+++ b/twostr_test/gen_2str_data.py
@@ -1,0 +1,113 @@
+"""
+This script is used to generate test cases for the ClimaLand TwoStream model
+implementation. The script generates a csv file with test cases for the
+TwoStream model compared against the outputs of a previous implementation of the
+TwoStream model:
+Quaife, T. 2016: PySellersTwoStream, available at:
+https://github.com/tquaife/pySellersTwoStream.
+We use a fork of the repository which has been patched to work with Python 3.
+
+This package does not allow for a clumping index while the ClimaLand
+implementation does. All other parameters used to generate the test data
+correspond to parameters in the ClimaLand implementation. The output data is a
+CSV file with each row corresponding to a test case. The columns are the 
+parameters: solar zenith angle, leaf area index, leaf/stem orientation index,
+leaf reflectance, leaf transmittance, soil albedo, the number of layers in the
+canopy, and the proportion of incident radiation which is diffuse. Then there is
+an output column for the fraction of absorbed photosynthetically active
+radiation (fAPAR).
+"""
+
+################################################################################
+# IMPORTS                                                                      #
+################################################################################
+
+import csv
+import sys
+from numpy import arange
+
+# Append the path to the sellersTwoStream package to python path
+sys.path.append("./py3SellersTwoStream")
+
+from sellersTwoStream import twoStream
+
+################################################################################
+# CONSTANTS                                                                    #
+################################################################################
+
+# Ranges to generate data over
+mu_range    = (0.1, 1)
+ld_range    = (0.1, 0.3)
+rho_range   = (0.1, 0.3)
+tau_range   = (0.1, 0.3)
+alb_range   = (0.1, 0.3)
+diff_range  = (0, 1)
+layer_range = (1, 5)
+LAI_range   = (3, 6)
+
+# columns to create in csv
+columns = ["mu", "LAI", "ld", "rho", "tau", "a_soil", "n_layers",
+           "prop_diffuse", "FAPAR"]
+
+################################################################################
+# MAIN                                                                         #
+################################################################################
+
+if __name__ == "__main__":
+    # Ensure the output file location was passed to the script
+    if len(sys.argv) != 2:
+        print("Usage: python gen_2str_data.py <output_file>")
+        sys.exit(1)
+
+    # Read the output file name from the command line
+    DATA_FILE = sys.argv[1]
+
+    # Create a TwoStream model
+    T = twoStream()
+    # For every combination of input parameters, calculate the fAPAR and write
+    # the input parameters and output fAPAR to csv file
+    with open(DATA_FILE, 'w') as out:
+        writer = csv.DictWriter(out, fieldnames=columns)
+        writer.writeheader()
+        for n in range(layer_range[0], layer_range[1]):
+            for prop in arange(diff_range[0], diff_range[1], 0.2):
+                for alb in arange(alb_range[0], alb_range[1], 0.1):
+                    for tau in arange(tau_range[0], tau_range[1], 0.1):
+                        for rho in arange(rho_range[0], rho_range[1], 0.1):
+                            for ld in arange(ld_range[0], ld_range[1], 0.1):
+                                for mu in arange(mu_range[0], mu_range[1], 0.2):
+                                    for LAI in arange(LAI_range[0],
+                                                      LAI_range[1], 1):
+                                        T.mu = mu
+                                        T.propDif = prop
+                                        T.lai = LAI
+                                        T.leaf_r = rho
+                                        T.leaf_t = tau
+                                        T.soil_r = alb
+                                        T.nLayers = n
+                                        T.G = lambda _ : ld
+                                        T.Z = lambda _ : 1
+                                        K = T.K_generic()
+                                        T.K = lambda: K
+                                        MB = T.muBar_generic()
+                                        T.muBar = lambda: MB
+                                        B_dir = \
+                                              T.B_direct_Dickinson_generic_ssa()
+                                        T.B_direct = lambda: B_dir
+                                        B_diff = T.B_diffuse_generic()
+                                        T.B_diffuse = lambda: B_diff
+                                        IupPAR, IdnPAR, IabPAR, Iab_dLaiPAR = \
+                                                                   T.getFluxes()
+                                        FAPAR = sum(IabPAR)
+                                        row = {
+                                            "mu":mu,
+                                            "LAI":LAI,
+                                            "ld":ld,
+                                            "rho":rho,
+                                            "tau":tau,
+                                            "a_soil":alb,
+                                            "n_layers":n,
+                                            "prop_diffuse":prop,
+                                            "FAPAR": FAPAR
+                                        }
+                                        writer.writerow(row)


### PR DESCRIPTION
<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

Move TwoStream test data to ClimaArtifacts to allow removal of ArtifactWrappers from ClimaLand.

Corresponding changes to ClimaLand are [here](https://github.com/CliMA/ClimaLand.jl/pull/910).

Checklist:
- [x] I created a new folder `$artifact_name`
  - [x] I added a `README.md` in that that folder that
    - [x] describes the data and processing done to it
    - [x] lists the sources of the raw data
    - [x] lists the required citation, licenses
  - [x] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [x] I added the scripts that retrieve, process, and produce the artifact
  - [x] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [x] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [x] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [x] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [x] I added a link to the main `README.md` to point to the new artifact

