### PR TITLE
Replace `Base.cp` with run(...).

### DIFF
--- a/ClimaArtifactsHelper.jl/src/ClimaArtifactsHelper.jl
+++ b/ClimaArtifactsHelper.jl/src/ClimaArtifactsHelper.jl
@@ -204,8 +204,12 @@ function create_artifact_guided_one_file(
         downloaded_file = download(file_url)
         Base.mv(downloaded_file, file_path)
     end
-
-    Base.cp(file_path, joinpath(output_dir, basename(file_path)))
+    # There are issues with large files in Base.cp https://github.com/JuliaLang/julia/issues/56537
+    if Sys.iswindows()
+        Base.cp(file_path, joinpath(output_dir, basename(file_path)))
+    else
+        run(`cp $file_path $(joinpath(output_dir, basename(file_path)))`)
+    end
 
     create_artifact_guided(output_dir; artifact_name, append)
 end


### PR DESCRIPTION
Replace `Base.cp` with run(...) on non-Windows operating systems.
`Base.cp` seems to have a bug when copying large files. Using `run` fixes this behaviour.
This fixes the bug mentioned in https://github.com/CliMA/ClimaArtifacts/pull/64

<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

Checklist:
- [ ] I created a new folder `$artifact_name`
  - [ ] I added a `README.md` in that that folder that
    - [ ] describes the data and processing done to it
    - [ ] lists the sources of the raw data
    - [ ] lists the required citation, licenses
  - [ ] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [ ] I added the scripts that retrieve, process, and produce the artifact
  - [ ] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [ ] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [ ] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [ ] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [ ] I added a link to the main `README.md` to point to the new artifact

