### PR TITLE
Add download callback to ClimaArtifactsHelper

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,15 @@ To create a new artifact in `ClimaArtifacts`:
 5. The `create_artifact_guided` starts a guided process that gives you the
    string to put in your `Artifacts.toml` files.
 
+If you are using `Downloads.jl`, you can use `download_rate_callback` to display
+the download rate and progress. An example of its usage is:
+
+```julia
+using Downloads
+using ClimaArtifactsHelper
+Downloads.download("https://www.foo.bar/baz.png"; progress = download_rate_callback())
+```
+
 If you are creating multiple artifacts from the same file, consider adding
 `append = true` to ensure that the `OutputArtifacts.toml` has all the
 information.

--- a/aerosol_concentrations/create_artifact.jl
+++ b/aerosol_concentrations/create_artifact.jl
@@ -165,7 +165,7 @@ end
 foreach(zip(FILE_PATHs, FILE_URLs)) do (path, url)
     if !isfile(path)
         @info "$path not found, downloading it (might take a while)"
-        aerosol_file = Downloads.download(url)
+        aerosol_file = Downloads.download(url; progress = download_rate_callback())
         Base.mv(aerosol_file, path)
     end
 end
@@ -187,7 +187,7 @@ end
 foreach(zip(FILE_PATHs, FILE_URLs)) do (path, url)
     if !isfile(path)
         @info "$path not found, downloading it (might take a while)"
-        aerosol_file = Downloads.download(url)
+        aerosol_file = Downloads.download(url; progress = download_rate_callback())
         Base.mv(aerosol_file, path)
     end
 end

--- a/bedrock_depth/create_artifact.jl
+++ b/bedrock_depth/create_artifact.jl
@@ -23,7 +23,7 @@ url = FILE_URL_30ARCSEC
 downloader = Downloads.Downloader()
 if !isfile(path)
     @info "$path not found, downloading it (might take a while)"
-    downloaded_file = Downloads.download(url)
+    downloaded_file = Downloads.download(url; progress = download_rate_callback())
     Base.mv(downloaded_file, path)
 end
 Base.cp(path, joinpath(output_dir_30arcsec, basename(path)))
@@ -42,7 +42,7 @@ url = FILE_URL_60ARCSEC
 downloader = Downloads.Downloader()
 if !isfile(path)
     @info "$path not found, downloading it (might take a while)"
-    downloaded_file = Downloads.download(url)
+    downloaded_file = Downloads.download(url; progress = download_rate_callback())
     Base.mv(downloaded_file, path)
 end
 Base.cp(path, joinpath(output_dir_60arcsec, basename(path)))

--- a/cesm2_albedo/create_artifact.jl
+++ b/cesm2_albedo/create_artifact.jl
@@ -40,7 +40,7 @@ for (file_path, file_url) in zip(FILE_PATHS, FILE_URLS)
             )
         println(file_url)
         println(file_path)
-        downloaded_file = Downloads.download(file_url; downloader)
+        downloaded_file = Downloads.download(file_url; downloader, progress = download_rate_callback())
         Base.mv(downloaded_file, file_path)
     end
 end

--- a/cfsite_gcm_forcing/create_artifact.jl
+++ b/cfsite_gcm_forcing/create_artifact.jl
@@ -15,7 +15,7 @@ end
 
 if !isfile(FILE_PATH)
     @info "$FILE_PATH not found, downloading it (might take a while)"
-    cfsite_gcm_forcing_file = Downloads.download(FILE_URL)
+    cfsite_gcm_forcing_file = Downloads.download(FILE_URL; progress = download_rate_callback())
     Base.mv(cfsite_gcm_forcing_file, FILE_PATH)
     Base.cp(FILE_PATH, joinpath(output_dir, basename(FILE_PATH)))
 end

--- a/clm_data/create_artifact.jl
+++ b/clm_data/create_artifact.jl
@@ -36,7 +36,7 @@ for (file_path, file_url) in zip(FILE_PATHS, FILE_URLS)
             )
         println(file_url)
         println(file_path)
-        downloaded_file = Downloads.download(file_url; downloader)
+        downloaded_file = Downloads.download(file_url; downloader, progress = download_rate_callback())
         Base.mv(downloaded_file, file_path)
     end
 end

--- a/co2_dataset/create_artifact.jl
+++ b/co2_dataset/create_artifact.jl
@@ -25,7 +25,7 @@ for (file_path, file_url) in zip(FILE_PATHS, FILE_URLS)
         downloader = Downloads.Downloader()
         println(file_url)
         println(file_path)
-        downloaded_file = Downloads.download(file_url; downloader)
+        downloaded_file = Downloads.download(file_url; downloader, progress = download_rate_callback())
         Base.mv(downloaded_file, file_path)
     end
 end

--- a/earth_orography/create_artifact.jl
+++ b/earth_orography/create_artifact.jl
@@ -29,7 +29,7 @@ downloader.easy_hook =
     )
 if !isfile(path)
     @info "$path not found, downloading it (might take a while)"
-    downloaded_file = Downloads.download(url)
+    downloaded_file = Downloads.download(url; progress = download_rate_callback())
     Base.mv(downloaded_file, path)
 end
 Base.cp(path, joinpath(output_dir_30arcsec, basename(path)))
@@ -54,7 +54,7 @@ downloader.easy_hook =
     )
 if !isfile(path)
     @info "$path not found, downloading it (might take a while)"
-    downloaded_file = Downloads.download(url)
+    downloaded_file = Downloads.download(url; progress = download_rate_callback())
     Base.mv(downloaded_file, path)
 end
 Base.cp(path, joinpath(output_dir_60arcsec, basename(path)))

--- a/historical_sst_sic/create_artifact.jl
+++ b/historical_sst_sic/create_artifact.jl
@@ -22,7 +22,7 @@ for (path, url) in
     (SIC_FILE_PATH => SIC_FILE_URL, SST_FILE_PATH => SST_FILE_URL)
     if !isfile(path)
         @info "$path not found, downloading it (might take a while)"
-        downloaded_file = Downloads.download(url)
+        downloaded_file = Downloads.download(url; progress = download_rate_callback())
         Base.mv(downloaded_file, path)
     end
     Base.cp(path, joinpath(output_dir, basename(path)))

--- a/ilamb_data/create_artifact.jl
+++ b/ilamb_data/create_artifact.jl
@@ -38,7 +38,7 @@ for (file_path, file_url, file_output) in zip(FILE_PATHS, FILE_URLS, FILE_OUTPUT
         downloader = Downloads.Downloader()
         println(file_url)
         println(file_path)
-        downloaded_file = Downloads.download(file_url; downloader)
+        downloaded_file = Downloads.download(file_url; downloader, progress = download_rate_callback())
         Base.mv(downloaded_file, file_path)
     end
     if haskey(preprocess_dict, file_path)

--- a/landsea_mask/create_artifacts.jl
+++ b/landsea_mask/create_artifacts.jl
@@ -21,7 +21,7 @@ end
 
 if !isfile(FILE_PATH_30ARCSEC)
     @info "$FILE_PATH_30ARCSEC not found, downloading it (might take a while)"
-    downloaded_file = Downloads.download(FILE_URL_30ARCSEC)
+    downloaded_file = Downloads.download(FILE_URL_30ARCSEC; progress = download_rate_callback())
     Base.mv(downloaded_file, FILE_PATH_30ARCSEC)
 end
 

--- a/ozone_concentrations/create_artifact.jl
+++ b/ozone_concentrations/create_artifact.jl
@@ -87,7 +87,7 @@ end
 foreach(zip(FILE_PATHs, FILE_URLs)) do (path, url)
     if !isfile(path)
     @info "$path not found, downloading it (might take a while)"
-        ozone_file = Downloads.download(url)
+        ozone_file = Downloads.download(url; progress = download_rate_callback())
         Base.mv(ozone_file, path)
     end
 end

--- a/precipitation_obs/create_artifact.jl
+++ b/precipitation_obs/create_artifact.jl
@@ -15,7 +15,7 @@ end
 
 if !isfile(FILE_PATH)
     @info "$FILE_PATH not found, downloading it (might take a while)"
-    precipitation_obs_file = Downloads.download(FILE_URL)
+    precipitation_obs_file = Downloads.download(FILE_URL; progress = download_rate_callback())
     Base.mv(precipitation_obs_file, FILE_PATH)
     Base.cp(FILE_PATH, joinpath(output_dir, basename(FILE_PATH)))
 end

--- a/snowmip/create_artifacts.jl
+++ b/snowmip/create_artifacts.jl
@@ -16,7 +16,7 @@ file_url = "https://hs.pangaea.de/Projects/ESM-SnowMIP/ESM-SnowMIP_all.zip"
 file_path = "ESM-SnowMIP_all.zip"
 if !isfile(file_path)
     @info "$file_path not found, downloading it (might take a while)"
-    file = Downloads.download(file_url)
+    file = Downloads.download(file_url; progress = download_rate_callback())
     Base.mv(file, file_path)
     mycommand = `unzip $file_path -d $outputdir`
     run(mycommand)

--- a/surface_temperatures/create_artifact.jl
+++ b/surface_temperatures/create_artifact.jl
@@ -7,17 +7,6 @@ const FILE_URL = "https://berkeley-earth-temperature.s3.us-west-1.amazonaws.com/
 
 const FILE_NAME = "Land_and_Ocean_LatLong1.nc"
 
-function download_progress(total::Integer, now::Integer)
-    if total == 0
-        print("Downloaded $(round(now/10^9, digits=2)) GB \r")
-    else
-        print(
-            "Downloaded $(round(now/10^9, digits=2)) out of $(round(total/10^9, digits=2)) GB: $(div(now * 100, total))% \r",
-        )
-    end
-end
-
-
 output_dir = basename(@__DIR__) * "_artifact"
 if isdir(output_dir)
     @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
@@ -28,14 +17,9 @@ end
 
 if !isfile(FILE_NAME)
     @info "$FILE_NAME not found, downloading it (might take a while)"
-    # The server has poor certificates, so we have to disable verification
-    downloader = Downloads.Downloader()
-    downloader.easy_hook =
-        (easy, info) ->
-            Downloads.Curl.setopt(easy, Downloads.Curl.CURLOPT_SSL_VERIFYPEER, false)
     println(FILE_URL)
     println(FILE_NAME)
-    downloaded_file = Downloads.download(FILE_URL; downloader, progress = download_progress)
+    downloaded_file = Downloads.download(FILE_URL; progress = download_rate_callback())
     Base.mv(downloaded_file, FILE_NAME)
 end
 


### PR DESCRIPTION
There are two callbacks in this PR. The first only prints the download progress, while the other also prints the download rate.

For both, total size is printed as  MB as an int if it is less than 1 GB, and GB with 2 decimal places otherwise. The same applies to dowloaded size and download rate.

The second callback is created with the function `create_download_rate_callback` which returns
a function. The callback calculates the
download rate over an interval, and prints the result at the end of
the interval. It also prints download progress. This callback
uses a closure to keep track of the time and bytes downloaded
at the end of the previous interval. If this callback is good,
then we can probably remove `download_progress_callback` from this PR.


I considered creating a wrapper for the download function, which would take in the file url and file name, and use the callback while downloading it, and then change the file name. This seems like it might be excessive. Thoughts?

Should I go through the existing artifacts and add the callback to the create_artifact.jl scripts?

Closes #68 
