### PR TITLE
Add forty years of ERA5 forcing data

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ S. Gupta et al 2022, 2024](https://github.com/CliMA/ClimaArtifacts/tree/main/soi
 - [TOPMODEL topographic index statistics](https:////github.com/CliMA/ClimaArtifacts/tree/main/topmodel)
 - [ERA5 Monthly Averages on Single Levels 1979-2024](https:////github.com/CliMA/ClimaArtifacts/tree/main/era5_monthly_averages_single_level_1979_2024)
 - [Lehmann et al. 2008 Fig. 8 evaporation data](https:////github.com/CliMA/ClimaArtifacts/tree/main/lehmann2008_evaporation)
+- [Forty years of ERA5 forcing data for ClimaLand](https:////github.com/CliMA/ClimaArtifacts/tree/main/forty_yrs_era5_land_forcing_data)
 
 ### Coupler/shared
 

--- a/forty_yrs_era5_land_forcing_data/Manifest.toml
+++ b/forty_yrs_era5_land_forcing_data/Manifest.toml
@@ -1,0 +1,526 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.11.1"
+manifest_format = "2.0"
+project_hash = "2f6cd22eb0855fe19451904a00cf004898ee4881"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.ArtifactUtils]]
+deps = ["Downloads", "Git", "HTTP", "Pkg", "ProgressLogging", "SHA", "TOML", "gh_cli_jll"]
+git-tree-sha1 = "f7c3ca6c70ea6b035effe5428eb05231ba890c2d"
+uuid = "8b73e784-e7d8-4ea5-973d-377fed4e3bce"
+version = "0.2.4"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BitFlags]]
+git-tree-sha1 = "0691e34b3bb8be9307330f88d1a3c3f25466c24d"
+uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+version = "0.1.9"
+
+[[deps.Blosc_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Lz4_jll", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "ef12cdd1c7fb7e1dfd6fa8fd60d4db6bc61d2f23"
+uuid = "0b7ba130-8d10-5ba8-a3d6-c5182647fed9"
+version = "1.21.6+0"
+
+[[deps.Bzip2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "8873e196c2eb87962a2048b3b8e08946535864a1"
+uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
+version = "1.0.8+2"
+
+[[deps.CFTime]]
+deps = ["Dates", "Printf"]
+git-tree-sha1 = "5afb5c5ba2688ca43a9ad2e5a91cbb93921ccfa1"
+uuid = "179af706-886a-5703-950a-314cd64e0468"
+version = "0.1.3"
+
+[[deps.ClimaArtifactsHelper]]
+deps = ["ArtifactUtils", "Downloads", "Pkg", "REPL", "SHA"]
+path = "/home/kphan2/.julia/dev/ClimaArtifacts/ClimaArtifactsHelper.jl"
+uuid = "6ffa2572-8378-4377-82eb-ea11db28b255"
+version = "0.0.1"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "bce6804e5e6044c6daab27bb533d1295e4a2e759"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.6"
+
+[[deps.CommonDataModel]]
+deps = ["CFTime", "DataStructures", "Dates", "Preferences", "Printf", "Statistics"]
+git-tree-sha1 = "98d64d5b9e5263884276656a43c45424b3a645c2"
+uuid = "1fbeeb36-5f17-413c-809b-666fb144f157"
+version = "0.3.7"
+
+[[deps.Compat]]
+deps = ["TOML", "UUIDs"]
+git-tree-sha1 = "8ae8d32e09f0dcf42a36b90d4e17f5dd2e4c4215"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "4.16.0"
+weakdeps = ["Dates", "LinearAlgebra"]
+
+    [deps.Compat.extensions]
+    CompatLinearAlgebraExt = "LinearAlgebra"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.1.1+0"
+
+[[deps.ConcurrentUtilities]]
+deps = ["Serialization", "Sockets"]
+git-tree-sha1 = "ea32b83ca4fefa1768dc84e504cc0a94fb1ab8d1"
+uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+version = "2.4.2"
+
+[[deps.DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "1d0a14036acb104d9e89698bd408f63ab58cdc82"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.20"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.DiskArrays]]
+deps = ["LRUCache", "OffsetArrays"]
+git-tree-sha1 = "e0e89a60637a62d13aa2107f0acd169b9b9b77e7"
+uuid = "3c3547ce-8d99-4f5e-a174-61eb10b00ae3"
+version = "0.4.6"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.ExceptionUnwrapping]]
+deps = ["Test"]
+git-tree-sha1 = "d36f682e590a83d63d1c7dbd287573764682d12a"
+uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
+version = "0.1.11"
+
+[[deps.Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "cc5231d52eb1771251fbd37171dbc408bcc8a1b6"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.6.4+0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.GMP_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
+version = "6.3.0+0"
+
+[[deps.Git]]
+deps = ["Git_jll"]
+git-tree-sha1 = "04eff47b1354d702c3a85e8ab23d539bb7d5957e"
+uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
+version = "1.3.1"
+
+[[deps.Git_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
+git-tree-sha1 = "ea372033d09e4552a04fd38361cd019f9003f4f4"
+uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
+version = "2.46.2+0"
+
+[[deps.GnuTLS_jll]]
+deps = ["Artifacts", "GMP_jll", "JLLWrappers", "Libdl", "Nettle_jll", "P11Kit_jll", "Zlib_jll"]
+git-tree-sha1 = "383db7d3f900f4c1f47a8a04115b053c095e48d3"
+uuid = "0951126a-58fd-58f1-b5b3-b08c7c4a876d"
+version = "3.8.4+0"
+
+[[deps.HDF5_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "libaec_jll"]
+git-tree-sha1 = "38c8874692d48d5440d5752d6c74b0c6b0b60739"
+uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
+version = "1.14.2+1"
+
+[[deps.HTTP]]
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "1336e07ba2eb75614c99496501a8f4b233e9fafe"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "1.10.10"
+
+[[deps.Hwloc_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "50aedf345a709ab75872f80a2779568dc0bb461b"
+uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
+version = "2.11.2+1"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "be3dc50a92e5a386872a493a10050136d4703f9b"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.6.1"
+
+[[deps.LLVMOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "78211fb6cbc872f77cad3fc0b6cf647d923f4929"
+uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
+version = "18.1.7+0"
+
+[[deps.LRUCache]]
+git-tree-sha1 = "b3cc6698599b10e652832c2f23db3cab99d51b59"
+uuid = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
+version = "1.6.1"
+weakdeps = ["Serialization"]
+
+    [deps.LRUCache.extensions]
+    SerializationExt = ["Serialization"]
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.6.0+0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.7.2+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "61dfdba58e585066d8bce214c5a51eaa0539f269"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.17.0+1"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.11.0"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "f02b56007b064fbfddb4c9cd60161b6dd0f40df3"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.1.0"
+
+[[deps.Lz4_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "abf88ff67f4fd89839efcae2f4c39cbc4ecd0846"
+uuid = "5ced341a-0733-55b8-9ab6-a4889d929147"
+version = "1.10.0+1"
+
+[[deps.MPICH_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "7715e65c47ba3941c502bffb7f266a41a7f54423"
+uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
+version = "4.2.3+0"
+
+[[deps.MPIPreferences]]
+deps = ["Libdl", "Preferences"]
+git-tree-sha1 = "c105fe467859e7f6e9a852cb15cb4301126fac07"
+uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
+version = "0.1.11"
+
+[[deps.MPItrampoline_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "70e830dab5d0775183c99fc75e4c24c614ed7142"
+uuid = "f1f71cc9-e9ae-5b93-9b94-4fe0e1ad3748"
+version = "5.5.1+0"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
+git-tree-sha1 = "c067a280ddc25f196b5e7df3877c6b226d390aaf"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.1.9"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.6+0"
+
+[[deps.MicrosoftMPI_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f12a29c4400ba812841c6ace3f4efbb6dbb3ba01"
+uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
+version = "10.1.4+2"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.12.12"
+
+[[deps.NCDatasets]]
+deps = ["CFTime", "CommonDataModel", "DataStructures", "Dates", "DiskArrays", "NetCDF_jll", "NetworkOptions", "Printf"]
+git-tree-sha1 = "2c9dc92001ac06d432f363f37ff5552954d9947c"
+uuid = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
+version = "0.14.6"
+
+[[deps.NetCDF_jll]]
+deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "OpenMPI_jll", "XML2_jll", "Zlib_jll", "Zstd_jll", "libzip_jll"]
+git-tree-sha1 = "a8af1798e4eb9ff768ce7fdefc0e957097793f15"
+uuid = "7243133f-43d8-5620-bbf4-c2c921802cf3"
+version = "400.902.209+0"
+
+[[deps.Nettle_jll]]
+deps = ["Artifacts", "GMP_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "eca63e3847dad608cfa6a3329b95ef674c7160b4"
+uuid = "4c82536e-c426-54e4-b420-14f461c4ed8b"
+version = "3.7.2+0"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.OffsetArrays]]
+git-tree-sha1 = "1a27764e945a152f7ca7efa04de513d473e9542e"
+uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
+version = "1.14.1"
+
+    [deps.OffsetArrays.extensions]
+    OffsetArraysAdaptExt = "Adapt"
+
+    [deps.OffsetArrays.weakdeps]
+    Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.27+1"
+
+[[deps.OpenMPI_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]
+git-tree-sha1 = "bfce6d523861a6c562721b262c0d1aaeead2647f"
+uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
+version = "5.0.5+0"
+
+[[deps.OpenSSL]]
+deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "OpenSSL_jll", "Sockets"]
+git-tree-sha1 = "38cb508d080d21dc1128f7fb04f20387ed4c0af4"
+uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
+version = "1.4.3"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "7493f61f55a6cce7325f197443aa80d32554ba10"
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.0.15+1"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.6.3"
+
+[[deps.P11Kit_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "2cd396108e178f3ae8dedbd8e938a18726ab2fbf"
+uuid = "c2071276-7c44-58a7-b746-946036e04d0a"
+version = "0.24.1+0"
+
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.42.0+1"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.11.0"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "9306f6085165d270f7e3db02af26a400d580f5c6"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.4.3"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.ProgressLogging]]
+deps = ["Logging", "SHA", "UUIDs"]
+git-tree-sha1 = "80d919dee55b9c50e8d9e2da5eeafff3fe58b539"
+uuid = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
+version = "0.1.4"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.SimpleBufferStream]]
+git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
+uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
+version = "1.2.0"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+version = "1.11.1"
+
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+    [deps.Statistics.weakdeps]
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
+
+[[deps.URIs]]
+git-tree-sha1 = "67db6cc7b3821e19ebe75791a9dd19c9b1188f2b"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.5.1"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
+git-tree-sha1 = "a2fccc6559132927d4c5dc183e3e01048c6dcbd6"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.13.5+0"
+
+[[deps.XZ_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "15e637a697345f6743674f1322beefbc5dcd5cfc"
+uuid = "ffd25f8a-64ca-5728-b0f7-c24cf3aae800"
+version = "5.6.3+0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
+
+[[deps.Zstd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "555d1076590a6cc2fdee2ef1469451f872d8b41b"
+uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
+version = "1.5.6+1"
+
+[[deps.gh_cli_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "b54ff233a6a183ad366d29fa0e3ff9bb921692db"
+uuid = "5d31d589-30fb-542f-b82d-10325e863e38"
+version = "2.35.0+0"
+
+[[deps.libaec_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "46bf7be2917b59b761247be3f317ddf75e50e997"
+uuid = "477f73a3-ac25-53e9-8cc3-50b2fa2566f0"
+version = "1.1.2+0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.11.0+0"
+
+[[deps.libzip_jll]]
+deps = ["Artifacts", "Bzip2_jll", "GnuTLS_jll", "JLLWrappers", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "668ac0297e6bd8f4d53dfdcd3ace71f2e00f4a35"
+uuid = "337d8026-41b4-5cde-a456-74a10e5b31d1"
+version = "1.11.1+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.59.0+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+2"

--- a/forty_yrs_era5_land_forcing_data/OutputArtifacts.toml
+++ b/forty_yrs_era5_land_forcing_data/OutputArtifacts.toml
@@ -1,0 +1,5 @@
+[forty_yrs_era5_land_forcing_data]
+git-tree-sha1 = "f269a0b057b9f438b4caafdef17da73746310787"
+[forty_yrs_era5_land_forcing_data_lai]
+git-tree-sha1 = "d009253aea5d2ca30009a65970227a8c28c6259b"
+

--- a/forty_yrs_era5_land_forcing_data/Project.toml
+++ b/forty_yrs_era5_land_forcing_data/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+ClimaArtifactsHelper = "6ffa2572-8378-4377-82eb-ea11db28b255"
+NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"

--- a/forty_yrs_era5_land_forcing_data/README.md
+++ b/forty_yrs_era5_land_forcing_data/README.md
@@ -1,0 +1,123 @@
+# ClimaLand forcing data - ERA5 reanalysis data for 1979 to 2024
+
+This artifact contains hourly ERA5 forcing data for ClimaLand simulations from the years
+1979 to 2024. The files are named `era5_YEAR_1.0x1.0.nc` and `era5_YEAR_1.0x1.0_lai.nc`. For
+2024, the latest datetime is 2024-11-08T01:00:00 because the dataset is downloaded on
+2024-11-13 at 01:50.
+
+In `era5_YEAR_1.0x1.0.nc`, the fields are
+- Latitude ("lat") (from -90.0 to 90.0 degrees at a resolution of 1.0 degree)
+- Longitude ("lon") (from 0.0 to 359.00 degrees at a resolution of 1.0 degree)
+- Time ("time")
+- 10 metre U wind component (lon, lat, time; "u10")
+- 10 metre V wind component (lon, lat, time; "v10")
+- Dew point temperature at 2 meters (lon, lat, time; "d2m")
+- Temperature at 2 meters (lon, lat, time; "t2m")
+- Surface air pressure (lon, lat, time; "sp")
+- Mean snowfall rate (lon, lat, time; "msr")
+- Mean surface direct short wave radiation flux (lon, lat, time; "msdrswrf")
+- Mean surface downward long wave radiation flux (lon, lat, time; "msdwlwrf")
+- Mean surface downward short wave radiation flux (lon, lat, time; "msdwswrf")
+- Mean total precipitation rate (lon, lat, time; "mtpr")
+
+The file `era5_YEAR_1.0x1.0_lai.nc` holds one year of weekly data for `lai_hv` and `lai_lv`.
+- Latitude ("lat") (from -90.0 to 90.0 degrees at a resolution of 1.0)
+- Longitude ("lon") (from 0.0 to 359.00 degrees at a resolution of 1.0)
+- Time ("time")
+- Leaf area index, high vegetation (lon, lat, time; "lai_hv")
+- Leaf area index, low vegetation (lon, lat, time; "lai_lv")
+
+## Prerequisites
+1. Python
+2. Julia
+3. ~1.5TB of storage size for download and postprocessing the data
+
+## Usage
+To recreate this artifact:
+1. Clone this repository and navigate to this directory.
+2. Run `pip install virtualenv` if you do not already have virtualenv installed.
+3. Run `virtualenv era5_download` to create an environment named `era5_download`.
+4. Run `source era5_download/bin/activate` to enter the virtual environment.
+5. Run `pip install -r requirements.txt` to install all the requirements.
+6. Create an account on https://cds.climate.copernicus.eu/.
+7. Find your Personal Access Token at https://cds.climate.copernicus.eu/profile.
+8a. Using your virtual environment, run the script (e.g. `python
+    get_era5_land_forcing_data.py YOUR_API_KEY YEAR_START YEAR_END MODE`) with
+    your API key from step 2 and your desired starting and ending years. Note that
+    YEAR_END is not included when download data. For instance, to download ERA5
+    data for the years 1979 to 2024 with all the variables, run
+    `python get_era5_land_forcing_data.py YOUR_API_KEY 1979 2025 all`. Alternatively,
+    run
+    `python get_era5_land_forcing_data.py YOUR_API_KEY 1979 2025 split`
+    to get the datasets split by instantaneous and rate variables. Downloading all the
+    variables in one file is faster than downloading the instantaneous and rate variables
+    in different files. However, when downloading all the variables in a single file, there
+    are cases where the variables are missing. One way to resolve this is to download
+    the rate and instantaneous variables separately. See the next step for checking if any
+    file is corrupted or missing.
+8b. Check for corrupted and missing files using `julia
+    find_corrupted_and_missing_nc_files.jl YEAR_START YEAR_END LAST_MONTH`. Note that
+    YEAR_END is included. For instance, to check corrupted files for the years 1979 to 2024
+    excluding the last month of 2024, then run
+    `julia --project=. find_corrupted_and_missing_nc_files.jl 1979 2024 11`. We say that a
+    file is corrupted if
+      1. Variables are missing
+      2. It cannot be open using NCDatasets
+      3. Duplicated points in time dimension
+      4. Time dimension is not sorted
+    After deleting the corrupted files, run the same command in step 8a. If the variables
+    are not downloaded properly, then try using `split` rather than `all`. Repeat step 8
+    until all files are verified to be correct by
+    `julia find_corrupted_and_missing_nc_files.jl YEAR_START YEAR_END LAST_MONTH`. The issue
+    of corruption of the dataset is due to the Copernicus backend. The frequency of errors
+    differ depending on what dataset and combination of variables are being downloaded.
+9. Run `julia --project=. create_artifact.jl` to create the artifact.
+
+## Post-processing
+- Updating history for global attributes.
+- The attribute `_FILLVALUE` is removed from the attributes of the variables "longitude" and
+  "latitude".
+- For all variables beside time, longitude, and latitude, every attribute is removed except
+  `standard_name`, `long_name`, `units`, `_FillValue`, and `missing_value`.
+- Reverse latitude dimension so that the latitudes are in increasing order.
+- All variables are stored as Float32 except for the time dimension which is
+  stored as Int32 (these are converted to dates when loading them in Julia).
+
+To be compatiable with the ClimaLand simulation, the postprocessing of reversing the
+latitude dimension is necessary. Furthermore, datasets downloaded separately, such as with
+the rate and instanteous variables, are stitched together, so that NCDatasets can read the
+stitched dataset as opposed to reading the datasets separately. Hence, to be able to read
+the raw ERA5 datasets, the ClimaLand simulation must support automatic reversing of the
+latitude dimension, the reversing of the corresponding axis of the data of the variables,
+and reading datasets containing different variables and different times.
+
+## Files
+The files included are `era5_YEAR_1.0x1.0.nc` and `era5_YEAR_1.0x1.0_lai.nc` for the years
+1979 to 2024. The total size of the artifact is around 1TB.
+
+## Code workarounds
+This script requests data monthly as smaller datasets are prioritized in the queue.
+However, a process can only have a single request at a time. To circumvent this, we
+spawn 144 processes and assign a request to each process. This ensures that we always have
+something in the queue. However, only a single request can be processed at a time which is
+the main bottleneck. Furthermore, the requests will not be processed if there are too many
+completed requests. There is no workaround for this, as the CDS API does not support
+deleting requests (see this [issue](https://github.com/ecmwf/cdsapi/issues/123)). To ensure
+a request is always being processed, one can manually delete completed requests.
+
+In some cases, datasets can be corrupted in the sense that the datasets are missing
+variables. Thus, this script also support downloading rate and instanteous variables in the
+command line arguments. Furthermore, the script `find_corrupted_and_missing_nc_files.jl` for
+finding corrupted files.
+
+## Attribution
+Hersbach, H. et al., (2018) was downloaded from the Copernicus Climate Change Service (2023). Our dataset contains modified Copernicus Climate Change Service information [2023]. Neither the European Commission nor ECMWF is responsible for any use that may be made of the Copernicus information or data it contains.
+
+Copernicus Climate Change Service (2023): ERA5 hourly data on single levels from 1940 to present. Copernicus Climate Change Service (C3S) Climate Data Store (CDS), DOI: 10.24381/cds.adbb2d47 (Accessed on 29-SEP-2023)
+
+Hersbach, H., Bell, B., Berrisford, P., Biavati, G., Horányi, A., Muñoz Sabater, J., Nicolas, J., Peubey, C., Radu, R., Rozum, I., Schepers, D., Simmons, A., Soci, C., Dee, D., Thépaut, J-N. (2018): ERA5 hourly data on single levels from 1940 to present. Copernicus Climate Change Service (C3S) Climate Data Store (CDS), DOI: 10.24381/cds.adbb2d47 , (Accessed on 29-SEP-2023)
+
+Hersbach, H., Bell, B., Berrisford, P., Hirahara, S., Horányi, A., Muñoz-Sabater, J., Nicolas, J., Peubey, C., Radu, R., Schepers, D., Simmons, A., Soci, C., Abdalla, S., Abellan, X., Balsamo, G., Bechtold, P., Biavati, G., Bidlot, J., Bonavita, M., … Thépaut, J.-N. (2020). The ERA5 global reanalysis. Quarterly Journal of the Royal Meteorological Society, 146(730), 1999–2049. https://doi.org/10.1002/QJ.3803
+
+## Licence
+Please see [License to Use Copernicus Products](https://object-store.os-api.cci2.ecmwf.int/cci2-prod-catalogue/licences/licence-to-use-copernicus-products/licence-to-use-copernicus-products_b4b9451f54cffa16ecef5c912c9cebd6979925a956e3fa677976e0cf198c2c18.pdf) for more information.

--- a/forty_yrs_era5_land_forcing_data/combine_rate_and_inst.jl
+++ b/forty_yrs_era5_land_forcing_data/combine_rate_and_inst.jl
@@ -1,0 +1,75 @@
+"""
+    combine_rate_and_inst(output_filepath, rate_filepath, inst_filepath)
+
+Stitch the datasets `rate_filepath` and `inst_filepath` by concatenating the variables
+together and save the new dataset as `output_filepath`.
+"""
+function combine_rate_and_inst(output_filepath, rate_filepath, inst_filepath)
+    # Load datasets
+    nc_rate = NCDataset(rate_filepath)
+    nc_inst = NCDataset(inst_filepath)
+
+    # Make new dataset
+    ds = NCDataset(output_filepath, "c", attrib = nc_rate.attrib)
+
+    defDim(ds, "valid_time", length(Array(nc_rate["valid_time"])))
+    defDim(ds, "latitude", length(Array(nc_rate["latitude"][:])))
+    defDim(ds, "longitude", length(Array(nc_rate["longitude"][:])))
+
+    # Define variables
+    ncnumber = defVar(ds, "number", Int64, (), attrib = nc_rate["number"].attrib)
+    ncvalid_time = defVar(
+        ds,
+        "valid_time",
+        Int64,
+        ("valid_time",),
+        attrib = nc_rate["valid_time"].attrib,
+    )
+    nclatitude =
+        defVar(ds, "latitude", Float64, ("latitude",), attrib = nc_rate["latitude"].attrib)
+    nclongitude = defVar(
+        ds,
+        "longitude",
+        Float64,
+        ("longitude",),
+        attrib = nc_rate["longitude"].attrib,
+    )
+    ncexpver = defVar(ds, "expver", String, ("valid_time",))
+
+    # Get values from dataset containing rate variables
+    ncnumber[] = Array(nc_rate["number"])
+    ncvalid_time[:] = Array(nc_rate["valid_time"])
+    nclatitude[:] = Array(nc_rate["latitude"])
+    nclongitude[:] = Array(nc_rate["longitude"])
+    ncexpver[:] = Array(nc_rate["expver"])
+
+    # Save all rate variables
+    rate_var_names = ["msr", "msdrswrf", "msdwlwrf", "msdwswrf", "mtpr"]
+    for var_name in rate_var_names
+        defVar(
+            ds,
+            var_name,
+            Float32,
+            ("longitude", "latitude", "valid_time"),
+            attrib = nc_rate[var_name].attrib,
+        )
+        ds[var_name][:, :, :] = nc_rate[var_name][:, :, :]
+    end
+
+    # Save all inst variables
+    inst_var_names = ["u10", "v10", "d2m", "t2m", "sp", "lai_lv", "lai_hv"]
+    for var_name in inst_var_names
+        defVar(
+            ds,
+            var_name,
+            Float32,
+            ("longitude", "latitude", "valid_time"),
+            attrib = nc_inst[var_name].attrib,
+        )
+        ds[var_name][:, :, :] = nc_inst[var_name][:, :, :]
+    end
+
+    close(nc_rate)
+    close(nc_inst)
+    close(ds)
+end

--- a/forty_yrs_era5_land_forcing_data/create_artifact.jl
+++ b/forty_yrs_era5_land_forcing_data/create_artifact.jl
@@ -1,0 +1,97 @@
+using ClimaArtifactsHelper
+using NCDatasets
+import OrderedCollections: OrderedDict
+
+include("postprocess_artifact.jl")
+include("postprocess_and_make_weekly_lai_data.jl")
+include("combine_rate_and_inst.jl")
+
+# Get all directories that start with "era_5"
+era_5_dirs = []
+for (_, dirs, _) in walkdir(".")
+    for dir in dirs
+        if startswith(dir, "era_5")
+            push!(era_5_dirs, dir)
+        end
+    end
+end
+
+# Make directories for artifacts
+output_dir = basename(@__DIR__) * "_artifact"
+if isdir(output_dir)
+    @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
+    @warn "Abort this calculation, unless you know what you are doing."
+else
+    mkdir(output_dir)
+end
+
+output_dir_lai = basename(@__DIR__) * "_lai"
+if isdir(output_dir_lai)
+    @warn "$output_dir_lai already exists. Content will end up in the artifact and may be overwritten."
+    @warn "Abort this calculation, unless you know what you are doing."
+else
+    mkdir(output_dir_lai)
+end
+
+completed_years = filter(x -> endswith(x, "_1.0x1.0.nc"), readdir(output_dir)) |> length
+remaining_years = length(era_5_dirs) - completed_years
+free_space_in_GB = diskstat().available / (1024^3) # convert from bytes to GB
+# One year of non-LAI data is approximately 22G
+required_space_in_GB = 22 * remaining_years
+
+if free_space_in_GB < required_space_in_GB
+    print("Insufficient space, free space: $free_space_in_GB GB and required space: $required_space_in_GB GB")
+end
+
+# Process each directory
+for dir in era_5_dirs
+    year = last(dir, 4)
+    file_paths = readdir(dir, join = true)
+
+    # Process *_rate.nc and *_inst.nc files and stitch them as a single file
+    rate_file_paths =
+        filter(file_path -> endswith(file_path, "rate.nc"), file_paths) |> sort
+    inst_file_paths =
+        filter(file_path -> endswith(file_path, "inst.nc"), file_paths) |> sort
+    for (rate_file_path, inst_file_path) in zip(rate_file_paths, inst_file_paths)
+        output_filepath = chop(rate_file_path, tail = 8) * ".nc"
+        isfile(output_filepath) && continue
+        combine_rate_and_inst(output_filepath, rate_file_path, inst_file_path)
+    end
+
+    # Filter to get only .nc files for monthly data
+    file_paths = readdir(dir, join = true)
+    nc_paths =
+        filter(file_path -> endswith(file_path, ".nc"), file_paths) |>
+        filter(file_path -> !(file_path in rate_file_paths)) |>
+        filter(file_path -> !(file_path in inst_file_paths)) |>
+        sort!
+
+    # Stitch all the months together and make the forcing data for each year as individual
+    # files
+    mfds = NCDataset(nc_paths, aggdim = "valid_time")
+
+    fileout = joinpath(output_dir, "era5_$(year)_1.0x1.0.nc")
+    if isfile(fileout)
+        println("$fileout already exists; skipping the creation of this file")
+    else
+        println("Processing $fileout")
+        thin_and_postprocess_artifact(mfds, fileout)
+    end
+
+    fileout_lai = joinpath(output_dir_lai, "era5_$(year)_1.0x1.0_lai.nc")
+    if isfile(fileout_lai)
+        println("$fileout_lai already exists; skipping the creation of this file")
+    else
+        println("Processing $fileout_lai")
+        postprocess_and_make_weekly_lai_data(mfds, fileout_lai)
+    end
+    close(mfds)
+end
+
+create_artifact_guided(output_dir; artifact_name = basename(@__DIR__))
+create_artifact_guided(
+    output_dir_lai;
+    artifact_name = basename(@__DIR__) * "_lai",
+    append = true,
+)

--- a/forty_yrs_era5_land_forcing_data/find_corrupted_and_missing_nc_files.jl
+++ b/forty_yrs_era5_land_forcing_data/find_corrupted_and_missing_nc_files.jl
@@ -1,0 +1,122 @@
+using NCDatasets
+
+"""
+    find_corrupted_and_missing_nc_files(first_year, last_year, last_month)
+
+Find corrupted and missing .nc files. Print the number of missing files and the missing
+files. If a file is corrupted, then an error is immediately thrown.
+
+A file is corrupted if:
+    1. Variables are missing
+    2. It cannot be open using NCDatasets
+    3. Duplicated points in time dimension
+    4. Time dimension is not sorted
+"""
+function find_corrupted_and_missing_nc_files(first_year, last_year, last_month)
+    years = first_year:1:last_year
+    months = ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]
+    file_names =
+        ["era5_forcing_data_$(year)_$(month).nc" for year in years for month in months]
+    file_names = file_names[begin:end-(12-last_month)]
+
+    era_5_dirs = []
+    for (_, dirs, _) in walkdir(".")
+        for dir in dirs
+            if startswith(dir, "era_5")
+                push!(era_5_dirs, dir)
+            end
+        end
+    end
+
+    rate_files = []
+    inst_files = []
+
+    for dir in era_5_dirs
+        files = readdir(dir, join = true)
+        for file in filter(x -> endswith(x, ".nc"), files)
+            println("Checking $file")
+            ds = NCDataset(file)
+            attribs = keys(ds)
+            # Data should contain all the variables
+            if !(occursin("rate", file) || occursin("inst", file))
+                if !issubset(
+                    [
+                        "u10",
+                        "v10",
+                        "d2m",
+                        "t2m",
+                        "sp",
+                        "msr",
+                        "msdrswrf",
+                        "msdwlwrf",
+                        "msdwswrf",
+                        "mtpr",
+                        "lai_hv",
+                        "lai_lv",
+                    ],
+                    attribs,
+                )
+                    println("$file is corrupted; does not contain all the variables")
+                    close(ds)
+                    continue
+                end
+                # Data should contain only the instantaneous variables
+            elseif occursin("inst", file)
+                if !issubset(
+                    ["u10", "v10", "d2m", "t2m", "sp", "lai_hv", "lai_lv"],
+                    attribs,
+                )
+                    println("$file is corrupted; does not contain all the variables")
+                    close(ds)
+                    continue
+                end
+            else
+                # Data should contain only rate variables
+                if !issubset(["msr", "msdrswrf", "msdwlwrf", "msdwswrf", "mtpr"], attribs)
+                    println("$file is corrupted; does not contain all the variables")
+                    close(ds)
+                    continue
+                end
+            end
+            # Check for duplicate time points
+            if !(unique(ds["valid_time"][:]) != length(ds["valid_time"][:]))
+                println("$file is corrupted; duplicated points in time dimension")
+                close(ds)
+                continue
+            end
+            # Check if time dimension is sorted
+            if !issorted(ds["valid_time"][:])
+                println("$file is corrupted, time dimension is not sorted")
+                close(ds)
+                continue
+            end
+            close(ds)
+            filter!(fname -> fname != basename(file), file_names)
+
+            occursin("rate", file) && push!(rate_files, basename(file))
+            occursin("inst", file) && push!(inst_files, basename(file))
+        end
+    end
+
+    without_rate_files = [chop(filename, tail = 8) * ".nc" for filename in rate_files]
+    without_inst_files = [chop(filename, tail = 8) * ".nc" for filename in inst_files]
+    rate_and_inst_files = intersect(without_rate_files, without_inst_files)
+    filter!(fname -> !(fname in rate_and_inst_files), file_names)
+    println("Missing or corrupted files: $file_names")
+    println("Missing or corrupted file count: $(length(file_names))")
+    return nothing
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    if length(ARGS) != 3
+        error(
+            "Script takes in three arguments: start year (inclusive), end year (inclusive), and last month",
+        )
+    end
+
+    # Check whether ERA5 data exists from the first month of first_year to last_month of last_year
+    first_year = parse(Int, ARGS[1])
+    last_year = parse(Int, ARGS[2])
+    last_month = parse(Int, ARGS[3])
+    find_corrupted_and_missing_nc_files(first_year, last_year, last_month)
+end

--- a/forty_yrs_era5_land_forcing_data/get_era5_land_forcing_data.py
+++ b/forty_yrs_era5_land_forcing_data/get_era5_land_forcing_data.py
@@ -1,0 +1,272 @@
+# API and command line interface
+import cdsapi
+import sys
+
+# For making multiple requests at the same time
+import concurrent.futures
+from itertools import repeat
+import copy
+
+# OS operations such as manipulating file paths and get file size
+import os.path
+import os
+import shutil
+
+def get_era5_forcing_data_for(YOUR_API_KEY, year, months):
+    """Get the ERA5 forcing data for ClimaLand for `months` from `year`."""
+    # Make file path from year and months
+    first_month = months[0]
+    filename = f"era5_forcing_data_{year}_{first_month}.nc"
+
+    dirpath = f"era_5_{year}"
+    try:
+        os.mkdir(dirpath)
+        print(f"Directory '{directory_name}' created successfully.")
+    except FileExistsError:
+        print(f"Directory '{dirpath}' already exists.")
+    except PermissionError:
+        print(f"Permission denied: Unable to create '{dirpath}'.")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+    filepath = os.path.join(dirpath, filename)
+
+    # If file exists, exit and do not make request
+    if os.path.isfile(filepath):
+        print(f"{filepath} already exists; will not request data")
+        return None
+
+    filename_inst = f"era5_forcing_data_{year}_{first_month}_inst.nc"
+    filename_rate = f"era5_forcing_data_{year}_{first_month}_rate.nc"
+    filepath_inst = os.path.join(dirpath, filename_inst)
+    filepath_rate = os.path.join(dirpath, filename_rate)
+    if os.path.isfile(filepath_inst) and os.path.isfile(filepath_rate):
+        print(f"{filepath_inst} and {filepath_rate} already exist; will not request data")
+        return None
+
+    dataset = "reanalysis-era5-single-levels"
+    request = {
+    "product_type": ["reanalysis"],
+    "variable": [
+        "10m_u_component_of_wind",
+        "10m_v_component_of_wind",
+        "2m_dewpoint_temperature",
+        "2m_temperature",
+        "surface_pressure",
+        "mean_snowfall_rate",
+        "mean_surface_direct_short_wave_radiation_flux",
+        "mean_surface_downward_long_wave_radiation_flux",
+        "mean_surface_downward_short_wave_radiation_flux",
+        "mean_total_precipitation_rate",
+        "leaf_area_index_high_vegetation",
+        "leaf_area_index_low_vegetation"
+    ],
+    "year": [year],
+    "month": months,
+    "day": [
+        "01", "02", "03",
+        "04", "05", "06",
+        "07", "08", "09",
+        "10", "11", "12",
+        "13", "14", "15",
+        "16", "17", "18",
+        "19", "20", "21",
+        "22", "23", "24",
+        "25", "26", "27",
+        "28", "29", "30",
+        "31"
+    ],
+    "time": [
+        "00:00", "01:00", "02:00",
+        "03:00", "04:00", "05:00",
+        "06:00", "07:00", "08:00",
+        "09:00", "10:00", "11:00",
+        "12:00", "13:00", "14:00",
+        "15:00", "16:00", "17:00",
+        "18:00", "19:00", "20:00",
+        "21:00", "22:00", "23:00"
+    ],
+    "data_format": "netcdf",
+    "download_format": "unarchived",
+    'grid'  : [1.0, 1.0]
+}
+    client = cdsapi.Client(url="https://cds.climate.copernicus.eu/api", key=YOUR_API_KEY)
+    result = client.retrieve(dataset, request, filepath)
+    return None
+
+def get_era5_forcing_split_data_for(YOUR_API_KEY, year, months):
+    """Get the ERA5 forcing data for ClimaLand for `months` from `year`, where
+    the rate and instantaneous variables are downloaded separately"""
+    # Make file path from year and months
+    first_month = months[0]
+    filename = f"era5_forcing_data_{year}_{first_month}.nc"
+    filename_inst = f"era5_forcing_data_{year}_{first_month}_inst.nc"
+    filename_rate = f"era5_forcing_data_{year}_{first_month}_rate.nc"
+
+    dirpath = f"era_5_{year}"
+    try:
+        os.mkdir(dirpath)
+        print(f"Directory '{directory_name}' created successfully.")
+    except FileExistsError:
+        print(f"Directory '{dirpath}' already exists.")
+    except PermissionError:
+        print(f"Permission denied: Unable to create '{dirpath}'.")
+    except Exception as e:
+        print(f"An error occurred: {e}")
+
+    filepath = os.path.join(dirpath, filename)
+    filepath_inst = os.path.join(dirpath, filename_inst)
+    filepath_rate = os.path.join(dirpath, filename_rate)
+
+    # If file exists, exit and do not make request
+    if os.path.isfile(filepath):
+        print(f"{filepath} already exists; will not request data")
+        return None
+
+    get_rate_data = True
+    get_inst_data = True
+
+    if os.path.isfile(filepath_rate):
+        print(f"{filepath_rate} already exists; will not request data")
+        get_rate_data = False
+    if os.path.isfile(filepath_inst):
+        print(f"{filepath_inst} already exists; will not request data")
+        get_inst_data = False
+
+    dataset = "reanalysis-era5-single-levels"
+    request_inst = {
+    "product_type": ["reanalysis"],
+    "variable": [
+        "10m_u_component_of_wind",
+        "10m_v_component_of_wind",
+        "2m_dewpoint_temperature",
+        "2m_temperature",
+        "surface_pressure",
+        "leaf_area_index_high_vegetation",
+        "leaf_area_index_low_vegetation"
+    ],
+    "year": [year],
+    "month": months,
+    "day": [
+        "01", "02", "03",
+        "04", "05", "06",
+        "07", "08", "09",
+        "10", "11", "12",
+        "13", "14", "15",
+        "16", "17", "18",
+        "19", "20", "21",
+        "22", "23", "24",
+        "25", "26", "27",
+        "28", "29", "30",
+        "31"
+    ],
+    "time": [
+        "00:00", "01:00", "02:00",
+        "03:00", "04:00", "05:00",
+        "06:00", "07:00", "08:00",
+        "09:00", "10:00", "11:00",
+        "12:00", "13:00", "14:00",
+        "15:00", "16:00", "17:00",
+        "18:00", "19:00", "20:00",
+        "21:00", "22:00", "23:00"
+    ],
+    "data_format": "netcdf",
+    "download_format": "unarchived",
+    'grid'  : [1.0, 1.0]
+}
+
+    if get_inst_data:
+        client_inst = cdsapi.Client(url="https://cds.climate.copernicus.eu/api", key=YOUR_API_KEY)
+        result_inst = client_inst.retrieve(dataset, request_inst, filepath_inst)
+
+    request_rate = copy.deepcopy(request_inst)
+    request_rate["variable"] = ["mean_snowfall_rate",
+        "mean_surface_direct_short_wave_radiation_flux",
+        "mean_surface_downward_long_wave_radiation_flux",
+        "mean_surface_downward_short_wave_radiation_flux",
+        "mean_total_precipitation_rate"]
+
+    if get_rate_data:
+        client_rate = cdsapi.Client(url="https://cds.climate.copernicus.eu/api", key=YOUR_API_KEY)
+        result_rate = client_rate.retrieve(dataset, request_rate, filepath_rate)
+    return None
+
+def find_remaining_files(path, year_begin, year_end):
+    """Get a list of the files that need to be downloaded for the years from `year_begin` to `year_end` - 1."""
+# Get all existing files
+    existing_files = []
+    dirpaths = ["era_5_" + str(year) for year in range(int(year_begin), int(year_end))]
+    for dirpath in dirpaths:
+        if os.path.exists(dirpath):
+            for path in os.listdir(dirpath):
+                if os.path.isfile(os.path.join(dirpath, path)):
+                    existing_files.append(os.path.join(dirpath, path))
+
+    # Compute files we need to get
+    files_to_get = []
+    for (year, dirpath) in zip(range(int(year_begin), int(year_end)), dirpaths):
+        for month in ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]:
+            files_to_get.append(os.path.join(dirpath, f"era5_forcing_data_{year}_{month}.nc"))
+
+    # Find the files we can remove
+    files_to_remove = []
+    for existing_file in existing_files:
+        if existing_file in files_to_get:
+            files_to_remove.append(existing_file)
+        else:
+            if existing_file.endswith("_inst.nc") and existing_file.replace("inst", "rate") in existing_files:
+                files_to_remove.append(existing_file.replace("_inst", ""))
+    remaining_files = filter(lambda file: file not in files_to_remove, files_to_get)
+    return list(remaining_files)
+
+if __name__ == "__main__":
+    API_KEY = str(sys.argv[1])
+    year_begin = str(sys.argv[2])
+    year_end = str(sys.argv[3])
+    mode = str(sys.argv[4]) # could be "all" or "split"
+
+    print(f"API_KEY: {API_KEY}")
+
+    path = "."
+    stat = shutil.disk_usage(path)
+    free_space_in_GB = stat.free / (1024**3) # convert from bytes to GB
+
+    # Find size of remaining files we need to download
+    # One year is approximately 8.4GB
+    required_space_in_GB = len(find_remaining_files(path, year_begin, year_end)) * (8.4 / 12.0)
+
+    if free_space_in_GB < required_space_in_GB:
+        print(f"Insufficient space, free space: {free_space_in_GB} GB and required space: {required_space_in_GB} GB")
+
+    # Split the requests over all the months and submit them all at once; otherwise, we get the
+    # error: Your request is too large, please reduce your selection.
+    months_to_split_by = [["01"], ["02"], ["03"], ["04"], ["05"], ["06"], ["07"], ["08"], ["09"], ["10"], ["11"], ["12"]]
+    months = []
+    years = []
+    for year in range(int(year_begin), int(year_end)):
+        for i in range(len(months_to_split_by)):
+            years.append(year)
+        months += months_to_split_by
+
+    # Convert to string because request does not works with integer values for years
+    years = list(map(str, years))
+
+
+    # This script requests data monthly as smaller datasets are prioritized in the queue.
+    # However, a process can only have a single request at a time. To circumvent this, we
+    # spawn 144 processes and assign a request to each process. This ensures that we always have
+    # something in the queue. However, only a single request can be processed at a time which is
+    #  the main bottleneck. Furthermore, the requests will not be processed if there are too many
+    # completed requests. There is no workaround for this, as the CDS API does not support
+    # deleting requests (see this [issue](https://github.com/ecmwf/cdsapi/issues/123)). To ensure
+    # a request is always being processed, one can manually delete completed requests.
+    # "all" is for downloading all the variables in one dataset
+    if mode == "all":
+        with concurrent.futures.ProcessPoolExecutor(max_workers = 144) as executor:
+            executor.map(get_era5_forcing_data_for, repeat(API_KEY), years, months)
+
+    # "split" is for downloading the rate and instantaneous variables separately
+    # This is helpful when there are errors in downloading the variables together
+    if mode == "split":
+        with concurrent.futures.ProcessPoolExecutor(max_workers = 144) as executor:
+            executor.map(get_era5_forcing_split_data_for, repeat(API_KEY), years, months)

--- a/forty_yrs_era5_land_forcing_data/postprocess_and_make_weekly_lai_data.jl
+++ b/forty_yrs_era5_land_forcing_data/postprocess_and_make_weekly_lai_data.jl
@@ -1,0 +1,97 @@
+"""
+   postprocess_and_make_weekly_lai_data(ncin, fileout)
+
+Take `ncin`, a .nc file loaded using NCDatasets, and write a postprocessed version to
+`fileout`.
+
+The variables kept are "lai_lv" and "lai_hv".
+
+Postprocessing includes:
+- Updating history for global attributes.
+- The attribute `_FILLVALUE` is removed from the attributes of the variables "longitude" and
+  "latitude".
+- For all variables beside time, longitude, and latitude, every attribute is removed except
+  `standard_name`, `long_name`, `units`, `_FillValue`, and `missing_value`.
+- Reverse latitude dimension so that the latitudes are in increasing order.
+- All variables are stored as Float32 except for the time dimension which is stored as Int32
+  (these are converted to dates when loading them in Julia).
+- Weekly data is kept which ranges from 2008-01-01 to 2008-12-23; the date 2008-12-30
+  excluded as it does not constitute a full week
+"""
+function postprocess_and_make_weekly_lai_data(ncin, fileout)
+    global_attrib = OrderedDict(ncin.attrib)
+    curr_history = global_attrib["history"]
+    new_history =
+        curr_history *
+        "; Modified by CliMA for use in ClimaLand models (see era5_land_forcing_data2008 folder in ClimaArtifacts for full changes)"
+    global_attrib["history"] = new_history
+    ncout = NCDataset(fileout, "c", attrib = global_attrib)
+
+    n_hours = length(ncin["valid_time"])
+    ntime = Int(floor(n_hours / (7 * 24)))
+    times = (0:1:(ntime-1)) .* 7 .* 24 .+ 1
+
+    defDim(ncout, "time", ntime)
+    defDim(ncout, "lon", Int(ceil(length(ncin["longitude"]))))
+    defDim(ncout, "lat", Int(ceil(length(ncin["latitude"]))))
+
+    time_ = defVar(
+        ncout,
+        "time",
+        Int32,
+        ("time",),
+        attrib = ncin["valid_time"].attrib,
+        deflatelevel = 0,
+    )
+
+    time_[:] = Array(ncin["valid_time"])[times]
+
+    lon = defVar(
+        ncout,
+        "lon",
+        Float32,
+        ("lon",),
+        attrib = delete!(copy(ncin["longitude"].attrib), "_FillValue"),
+        deflatelevel = 0,
+    )
+    lon[:] = Array(ncin["longitude"])
+
+    lat = defVar(
+        ncout,
+        "lat",
+        Float32,
+        ("lat",),
+        attrib = copy(ncin["latitude"].attrib) |>
+                 x -> delete!(x, "_FillValue") |> x -> delete!(x, "stored_direction"),
+        deflatelevel = 0,
+    )
+
+    # Reverse latitude dimension so that the elements are in increasing order
+    lat[:] = reverse(Array(ncin["latitude"]))
+
+
+    varnames = ["lai_hv", "lai_lv"]
+
+    attrib_names =
+        ["standard_name", "long_name", "units", "_FillValue", "GRIB_missingValue"]
+    attrib_renames = ["standard_name", "long_name", "units", "_FillValue", "missing_value"]
+
+    for varname in varnames
+        @show varname
+        attribs = Dict([
+            attrib_rename => ncin[varname].attrib[attrib_name] for
+            (attrib_name, attrib_rename) in zip(attrib_names, attrib_renames)
+        ])
+        defVar(
+            ncout,
+            varname,
+            Float32,
+            ("lon", "lat", "time"),
+            attrib = attribs,
+            deflatelevel = 0,
+        )
+        ncout[varname][:, :, :] = reverse(ncin[varname][:, :, times], dims = 2)
+    end
+
+    close(ncout)
+end

--- a/forty_yrs_era5_land_forcing_data/postprocess_artifact.jl
+++ b/forty_yrs_era5_land_forcing_data/postprocess_artifact.jl
@@ -1,0 +1,102 @@
+"""
+   postprocess_artifact(ncin, fileout)
+
+Take a `ncin` ,a .nc file loaded using NCDatasets, and write a postprocessed thinned-down
+version to `fileout`.
+
+The variables kept are "u10", "v10", "d2m", "t2m", "sp", "msr", "msdrswrf", "msdwlwrf",
+"msdwswrf", and "mtpr".
+
+Postprocessing includes:
+- Updating history for global attributes.
+- The attribute `_FILLVALUE` is removed from the attributes of the variables "longitude" and
+  "latitude".
+- For all variables beside time, longitude, and latitude, every attribute is removed except
+  `standard_name`, `long_name`, `units`, `_FillValue`, and `missing_value`.
+- Reverse latitude dimension so that the latitudes are in increasing order.
+- All variables are stored as Float32 except for the time dimension which is stored as Int32
+  (these are converted to dates when loading them in Julia).
+"""
+function postprocess_artifact(ncin, fileout)
+    global_attrib = OrderedDict(ncin.attrib)
+    curr_history = global_attrib["history"]
+    new_history =
+        curr_history *
+        "; Modified by CliMA for use in ClimaLand models (see era5_land_forcing_data2008 folder in ClimaArtifacts for full changes)"
+    global_attrib["history"] = new_history
+    ncout = NCDataset(fileout, "c", attrib = global_attrib)
+
+    defDim(ncout, "time", length(ncin["valid_time"]))
+    defDim(ncout, "lon", length(ncin["longitude"]))
+    defDim(ncout, "lat", length(ncin["latitude"]))
+
+    time_ = defVar(
+        ncout,
+        "time",
+        Int32,
+        ("time",),
+        attrib = ncin["valid_time"].attrib,
+        deflatelevel = 0,
+    )
+
+    time_[:] = Array(ncin["valid_time"])
+
+    lon = defVar(
+        ncout,
+        "lon",
+        Float32,
+        ("lon",),
+        attrib = delete!(copy(ncin["longitude"].attrib), "_FillValue"),
+        deflatelevel = 0,
+    )
+    lon[:] = Array(ncin["longitude"])[begin:end]
+
+    lat = defVar(
+        ncout,
+        "lat",
+        Float32,
+        ("lat",),
+        attrib = copy(ncin["latitude"].attrib) |>
+                 x -> delete!(x, "_FillValue") |> x -> delete!(x, "stored_direction"),
+        deflatelevel = 0,
+    )
+
+    # Reverse latitude dimension so that the elements are in increasing order
+    lat[:] = reverse(Array(ncin["latitude"]))[begin:end]
+
+    varnames = [
+        "u10",
+        "v10",
+        "d2m",
+        "t2m",
+        "sp",
+        "msr",
+        "msdrswrf",
+        "msdwlwrf",
+        "msdwswrf",
+        "mtpr",
+    ]
+
+    attrib_names =
+        ["standard_name", "long_name", "units", "_FillValue", "GRIB_missingValue"]
+    attrib_renames = ["standard_name", "long_name", "units", "_FillValue", "missing_value"]
+
+    for varname in varnames
+        @show varname
+        attribs = Dict([
+            attrib_rename => ncin[varname].attrib[attrib_name] for
+            (attrib_name, attrib_rename) in zip(attrib_names, attrib_renames)
+        ])
+        defVar(
+            ncout,
+            varname,
+            Float32,
+            ("lon", "lat", "time"),
+            attrib = attribs,
+            deflatelevel = 0,
+        )
+        ncout[varname][:, :, :] = reverse(ncin[varname][begin:end, begin:end, :], dims = 2)
+    end
+
+    close(ncout)
+end

--- a/forty_yrs_era5_land_forcing_data/requirements.txt
+++ b/forty_yrs_era5_land_forcing_data/requirements.txt
@@ -1,0 +1,14 @@
+attrs==24.2.0
+cads-api-client==1.5.2
+cdsapi==0.7.4
+certifi==2024.8.30
+charset-normalizer==3.4.0
+idna==3.10
+multiurl==0.3.2
+python-dateutil==2.9.0.post0
+pytz==2024.2
+requests==2.32.3
+six==1.16.0
+tqdm==4.67.0
+typing_extensions==4.12.2
+urllib3==2.2.3


### PR DESCRIPTION
This PR adds forty years of ERA5 forcing data.

The ERA5 forcing data is at `/net/sampo/data1/era5/forty_yrs_era5_land_forcing_data/forty_yrs_era5_land_forcing_data_artifact`. As of now, it will not be moved to the cluster, because it is around 1TB.

Checklist:
- [X] I created a new folder `$artifact_name`
  - [X] I added a `README.md` in that that folder that
    - [X] describes the data and processing done to it
    - [X] lists the sources of the raw data
    - [X] lists the required citation, licenses
  - [X] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [X] I added the scripts that retrieve, process, and produce the artifact
  - [X] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [X] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [x] I uploaded the artifact folder (lai data) to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [x] I added the relevant code (for lai data) to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [ ] I uploaded the artifact folder (for non-lai data) to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [ ] I added the relevant code (for non-lai data) to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [x] I added a link to the main `README.md` to point to the new artifact
