### PR TITLE
Remove compression for ERA5 forcing data for land

### DIFF
--- a/era5_land_forcing_data2008/OutputArtifacts.toml
+++ b/era5_land_forcing_data2008/OutputArtifacts.toml
@@ -1,15 +1,14 @@
 [era5_land_forcing_data2008]
 git-tree-sha1 = "93d2e93f491e77cb8fba2a1b8b3946f38bde469e"
 [era5_land_forcing_data2008_lowres]
-git-tree-sha1 = "67b6daae491c1fa55406dd6a65f6b197b9bd4728"
+git-tree-sha1 = "fd826542e6ab1758c8d5a2cc6dbf1f67b47aadee"
 
     [[era5_land_forcing_data2008_lowres.download]]
-    sha256 = "f1ec64818faad37cf681caa86832b77c68f93784bf105dc85dd57079e8673b10"
+    sha256 = "c5ea5acfcab2e69c26d6ef8ba20e9e6dc018e5baa9c48d0df69cf0a5f9bf3399"
     url = "https://caltech.box.com/shared/static/6zk5fa3ka5ib62jsrs6tx35sqwe8xv2k.gz"
-
 [era5_land_forcing_data2008_lai]
-git-tree-sha1 = "f998a8db24647caf5f1693ad4a1e46bdf356a752"
+git-tree-sha1 = "df5ec5af1ea0793c0e7d49e60db5a938098e174f"
 
     [[era5_land_forcing_data2008_lai.download]]
-    sha256 = "81b357e97daf18d998c003dc00db14a7ffdd431520f2c5c4e41a1f0254864a8d"
+    sha256 = "a83bf28a7a864db285e41289031a9761c2a426373a6efecd04b866a0b5374cef"
     url = "https://caltech.box.com/shared/static/m82r23e67x04a3hb6p79dfltlumvg9z0.gz"

--- a/era5_land_forcing_data2008/README.md
+++ b/era5_land_forcing_data2008/README.md
@@ -62,9 +62,9 @@ To recreate this artifact:
   and longitude.
 
 ## Files
-- `era5_2008_0.9x1.25.nc` (~10.37GB)
-- `era5_2008_0.9x1.25_lowres.nc` (~192.82MB)
-- `era5_2008_0.9x1.25_lai.nc` (~3.56MB)
+- `era5_2008_0.9x1.25.nc` (~21.32GB)
+- `era5_2008_0.9x1.25_lowres.nc` (~346.87MB)
+- `era5_2008_0.9x1.25_lai.nc` (~25.87MB)
 
 ## Attribution
 Hersbach, H. et al., (2018) was downloaded from the Copernicus Climate Change Service (2023). Our dataset contains modified Copernicus Climate Change Service information [2023]. Neither the European Commission nor ECMWF is responsible for any use that may be made of the Copernicus information or data it contains.

--- a/era5_land_forcing_data2008/postprocess_and_make_weekly_lai_data.jl
+++ b/era5_land_forcing_data2008/postprocess_and_make_weekly_lai_data.jl
@@ -41,7 +41,7 @@ function postprocess_and_make_weekly_lai_data(ncin, fileout)
         Int32,
         ("time",),
         attrib = ncin["valid_time"].attrib,
-        deflatelevel = 9,
+        deflatelevel = 0,
     )
 
     time_[:] = Array(ncin["valid_time"])[times]
@@ -52,7 +52,7 @@ function postprocess_and_make_weekly_lai_data(ncin, fileout)
         Float32,
         ("lon",),
         attrib = delete!(copy(ncin["longitude"].attrib), "_FillValue"),
-        deflatelevel = 9,
+        deflatelevel = 0,
     )
     lon[:] = Array(ncin["longitude"])
 
@@ -63,7 +63,7 @@ function postprocess_and_make_weekly_lai_data(ncin, fileout)
         ("lat",),
         attrib = copy(ncin["latitude"].attrib) |>
                  x -> delete!(x, "_FillValue") |> x -> delete!(x, "stored_direction"),
-        deflatelevel = 9,
+        deflatelevel = 0,
     )
 
     # Reverse latitude dimension so that the elements are in increasing order
@@ -88,7 +88,7 @@ function postprocess_and_make_weekly_lai_data(ncin, fileout)
             Float32,
             ("lon", "lat", "time"),
             attrib = attribs,
-            deflatelevel = 9,
+            deflatelevel = 0,
         )
         ncout[varname][:, :, :] = reverse(ncin[varname][:, :, times], dims = 2)
     end

--- a/era5_land_forcing_data2008/thin_and_postprocess_artifact.jl
+++ b/era5_land_forcing_data2008/thin_and_postprocess_artifact.jl
@@ -39,7 +39,7 @@ function thin_and_postprocess_artifact(ncin, fileout; THINNING_FACTOR = 8)
         Int32,
         ("time",),
         attrib = ncin["valid_time"].attrib,
-        deflatelevel = 9,
+        deflatelevel = 0,
     )
 
     time_[:] = Array(ncin["valid_time"])
@@ -50,7 +50,7 @@ function thin_and_postprocess_artifact(ncin, fileout; THINNING_FACTOR = 8)
         Float32,
         ("lon",),
         attrib = delete!(copy(ncin["longitude"].attrib), "_FillValue"),
-        deflatelevel = 9,
+        deflatelevel = 0,
     )
     lon[:] = Array(ncin["longitude"])[begin:THINNING_FACTOR:end]
 
@@ -61,7 +61,7 @@ function thin_and_postprocess_artifact(ncin, fileout; THINNING_FACTOR = 8)
         ("lat",),
         attrib = copy(ncin["latitude"].attrib) |>
                  x -> delete!(x, "_FillValue") |> x -> delete!(x, "stored_direction"),
-        deflatelevel = 9,
+        deflatelevel = 0,
     )
 
     # Reverse latitude dimension so that the elements are in increasing order
@@ -96,7 +96,7 @@ function thin_and_postprocess_artifact(ncin, fileout; THINNING_FACTOR = 8)
             Float32,
             ("lon", "lat", "time"),
             attrib = attribs,
-            deflatelevel = 9,
+            deflatelevel = 0,
         )
         ncout[varname][:, :, :] = reverse(
             ncin[varname][begin:THINNING_FACTOR:end, begin:THINNING_FACTOR:end, :],


### PR DESCRIPTION
Compression doubles the size of the file, but makes running the simulation much faster.


<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

Checklist:
- [x] I created a new folder `$artifact_name`
  - [x] I added a `README.md` in that that folder that
    - [x] describes the data and processing done to it
    - [x] lists the sources of the raw data
    - [x] lists the required citation, licenses
  - [x] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [x] I added the scripts that retrieve, process, and produce the artifact
  - [x] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [x] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [x] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [x] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [x] I added a link to the main `README.md` to point to the new artifact

