### PR TITLE
Reduce compression on era5 monthly averages

### DIFF
--- a/era5_monthly_averages_2008/Manifest.toml
+++ b/era5_monthly_averages_2008/Manifest.toml
@@ -1,12 +1,12 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.10.5"
+julia_version = "1.11.1"
 manifest_format = "2.0"
 project_hash = "47774df903631abd3b74628cc1eb8ab16058d1db"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
-version = "1.1.1"
+version = "1.1.2"
 
 [[deps.ArtifactUtils]]
 deps = ["Downloads", "Git", "HTTP", "Pkg", "ProgressLogging", "SHA", "TOML", "gh_cli_jll"]
@@ -16,9 +16,11 @@ version = "0.2.4"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
 
 [[deps.BitFlags]]
 git-tree-sha1 = "0691e34b3bb8be9307330f88d1a3c3f25466c24d"
@@ -45,7 +47,7 @@ version = "0.1.3"
 
 [[deps.ClimaArtifactsHelper]]
 deps = ["ArtifactUtils", "Downloads", "Pkg", "REPL", "SHA"]
-path = "/Users/treddy/.julia/dev/ClimaArtifacts/ClimaArtifactsHelper.jl"
+path = "../ClimaArtifactsHelper.jl"
 uuid = "6ffa2572-8378-4377-82eb-ea11db28b255"
 version = "0.0.1"
 
@@ -57,9 +59,9 @@ version = "0.7.6"
 
 [[deps.CommonDataModel]]
 deps = ["CFTime", "DataStructures", "Dates", "Preferences", "Printf", "Statistics"]
-git-tree-sha1 = "d6fb5bf939a2753c74984b11434ea25d6c397a58"
+git-tree-sha1 = "98d64d5b9e5263884276656a43c45424b3a645c2"
 uuid = "1fbeeb36-5f17-413c-809b-666fb144f157"
-version = "0.3.6"
+version = "0.3.7"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
@@ -91,6 +93,7 @@ version = "0.18.20"
 [[deps.Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
 
 [[deps.DiskArrays]]
 deps = ["LRUCache", "OffsetArrays"]
@@ -105,23 +108,19 @@ version = "1.6.0"
 
 [[deps.ExceptionUnwrapping]]
 deps = ["Test"]
-git-tree-sha1 = "dcb08a0d93ec0b1cdc4af184b26b591e9695423a"
+git-tree-sha1 = "d36f682e590a83d63d1c7dbd287573764682d12a"
 uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
-version = "0.1.10"
+version = "0.1.11"
 
 [[deps.Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "1c6317308b9dc757616f0b5cb379db10494443a7"
+git-tree-sha1 = "cc5231d52eb1771251fbd37171dbc408bcc8a1b6"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.6.2+0"
+version = "2.6.4+0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
-
-[[deps.GMP_jll]]
-deps = ["Artifacts", "Libdl"]
-uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
-version = "6.2.1+6"
+version = "1.11.0"
 
 [[deps.Git]]
 deps = ["Git_jll"]
@@ -135,45 +134,34 @@ git-tree-sha1 = "ea372033d09e4552a04fd38361cd019f9003f4f4"
 uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
 version = "2.46.2+0"
 
-[[deps.GnuTLS_jll]]
-deps = ["Artifacts", "GMP_jll", "JLLWrappers", "Libdl", "Nettle_jll", "P11Kit_jll", "Zlib_jll"]
-git-tree-sha1 = "383db7d3f900f4c1f47a8a04115b053c095e48d3"
-uuid = "0951126a-58fd-58f1-b5b3-b08c7c4a876d"
-version = "3.8.4+0"
-
 [[deps.HDF5_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LLVMOpenMP_jll", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "libaec_jll"]
-git-tree-sha1 = "38c8874692d48d5440d5752d6c74b0c6b0b60739"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "OpenSSL_jll", "TOML", "Zlib_jll", "libaec_jll"]
+git-tree-sha1 = "82a471768b513dc39e471540fdadc84ff80ff997"
 uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
-version = "1.14.2+1"
+version = "1.14.3+3"
 
 [[deps.HTTP]]
-deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
-git-tree-sha1 = "bc3f416a965ae61968c20d0ad867556367f2817d"
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "ae350b8225575cc3ea385d4131c81594f86dfe4f"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "1.10.9"
+version = "1.10.12"
 
 [[deps.Hwloc_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "dd3b49277ec2bb2c6b94eb1604d4d0616016f7a6"
+git-tree-sha1 = "50aedf345a709ab75872f80a2779568dc0bb461b"
 uuid = "e33a78d0-f292-5ffc-b300-72abe9b543c8"
-version = "2.11.2+0"
+version = "2.11.2+1"
 
 [[deps.InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
 
 [[deps.JLLWrappers]]
 deps = ["Artifacts", "Preferences"]
 git-tree-sha1 = "be3dc50a92e5a386872a493a10050136d4703f9b"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
 version = "1.6.1"
-
-[[deps.LLVMOpenMP_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "78211fb6cbc872f77cad3fc0b6cf647d923f4929"
-uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
-version = "18.1.7+0"
 
 [[deps.LRUCache]]
 git-tree-sha1 = "b3cc6698599b10e652832c2f23db3cab99d51b59"
@@ -187,6 +175,7 @@ weakdeps = ["Serialization"]
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
 uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+version = "1.11.0"
 
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -196,16 +185,17 @@ version = "0.6.4"
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
-version = "8.4.0+0"
+version = "8.6.0+0"
 
 [[deps.LibGit2]]
 deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
 
 [[deps.LibGit2_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
 uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
-version = "1.6.4+0"
+version = "1.7.2+0"
 
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
@@ -214,6 +204,7 @@ version = "1.11.0+1"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
 
 [[deps.Libiconv_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -224,9 +215,11 @@ version = "1.17.0+1"
 [[deps.LinearAlgebra]]
 deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.11.0"
 
 [[deps.Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
 
 [[deps.LoggingExtras]]
 deps = ["Dates", "Logging"]
@@ -261,6 +254,7 @@ version = "5.5.1+0"
 [[deps.Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
 
 [[deps.MbedTLS]]
 deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
@@ -271,17 +265,17 @@ version = "1.1.9"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.28.2+1"
+version = "2.28.6+0"
 
 [[deps.MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "f12a29c4400ba812841c6ace3f4efbb6dbb3ba01"
+git-tree-sha1 = "bc95bf4149bf535c09602e3acdf950d9b4376227"
 uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
-version = "10.1.4+2"
+version = "10.1.4+3"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
-version = "2023.1.10"
+version = "2023.12.12"
 
 [[deps.NCDatasets]]
 deps = ["CFTime", "CommonDataModel", "DataStructures", "Dates", "DiskArrays", "NetCDF_jll", "NetworkOptions", "Printf"]
@@ -290,16 +284,10 @@ uuid = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 version = "0.14.6"
 
 [[deps.NetCDF_jll]]
-deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "OpenMPI_jll", "XML2_jll", "Zlib_jll", "Zstd_jll", "libzip_jll"]
-git-tree-sha1 = "a8af1798e4eb9ff768ce7fdefc0e957097793f15"
+deps = ["Artifacts", "Blosc_jll", "Bzip2_jll", "HDF5_jll", "JLLWrappers", "LazyArtifacts", "LibCURL_jll", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "TOML", "XML2_jll", "Zlib_jll", "Zstd_jll", "libzip_jll"]
+git-tree-sha1 = "4686378c4ae1d1948cfbe46c002a11a4265dcb07"
 uuid = "7243133f-43d8-5620-bbf4-c2c921802cf3"
-version = "400.902.209+0"
-
-[[deps.Nettle_jll]]
-deps = ["Artifacts", "GMP_jll", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "eca63e3847dad608cfa6a3329b95ef674c7160b4"
-uuid = "4c82536e-c426-54e4-b420-14f461c4ed8b"
-version = "3.7.2+0"
+version = "400.902.211+1"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
@@ -319,13 +307,13 @@ version = "1.14.1"
 [[deps.OpenBLAS_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
 uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
-version = "0.3.23+4"
+version = "0.3.27+1"
 
 [[deps.OpenMPI_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "Hwloc_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML", "Zlib_jll"]
-git-tree-sha1 = "bfce6d523861a6c562721b262c0d1aaeead2647f"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "e25c1778a98e34219a00455d6e4384e017ea9762"
 uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
-version = "5.0.5+0"
+version = "4.1.6+0"
 
 [[deps.OpenSSL]]
 deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "OpenSSL_jll", "Sockets"]
@@ -344,21 +332,25 @@ git-tree-sha1 = "dfdf5519f235516220579f949664f1bf44e741c5"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.6.3"
 
-[[deps.P11Kit_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "2cd396108e178f3ae8dedbd8e938a18726ab2fbf"
-uuid = "c2071276-7c44-58a7-b746-946036e04d0a"
-version = "0.24.1+0"
-
 [[deps.PCRE2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
 version = "10.42.0+1"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
-version = "1.10.0"
+version = "1.11.0"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
@@ -369,6 +361,7 @@ version = "1.4.3"
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
 
 [[deps.ProgressLogging]]
 deps = ["Logging", "SHA", "UUIDs"]
@@ -377,12 +370,14 @@ uuid = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
 version = "0.1.4"
 
 [[deps.REPL]]
-deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "StyledStrings", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
 
 [[deps.Random]]
 deps = ["SHA"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
@@ -390,6 +385,7 @@ version = "0.7.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
 
 [[deps.SimpleBufferStream]]
 git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
@@ -398,21 +394,23 @@ version = "1.2.0"
 
 [[deps.Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
-
-[[deps.SparseArrays]]
-deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
-uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-version = "1.10.0"
+version = "1.11.0"
 
 [[deps.Statistics]]
-deps = ["LinearAlgebra", "SparseArrays"]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "ae3bb1eb3bba077cd276bc5cfc337cc65c3075c0"
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-version = "1.10.0"
+version = "1.11.1"
 
-[[deps.SuiteSparse_jll]]
-deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
-uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
-version = "7.2.1+1"
+    [deps.Statistics.extensions]
+    SparseArraysExt = ["SparseArrays"]
+
+    [deps.Statistics.weakdeps]
+    SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
 
 [[deps.TOML]]
 deps = ["Dates"]
@@ -427,6 +425,7 @@ version = "1.10.0"
 [[deps.Test]]
 deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
 
 [[deps.TranscodingStreams]]
 git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
@@ -441,15 +440,17 @@ version = "1.5.1"
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
 
 [[deps.Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
 
 [[deps.XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Zlib_jll"]
-git-tree-sha1 = "6a451c6f33a176150f315726eba8b92fbfdb9ae7"
+git-tree-sha1 = "a2fccc6559132927d4c5dc183e3e01048c6dcbd6"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.13.4+0"
+version = "2.13.5+0"
 
 [[deps.XZ_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
@@ -486,15 +487,15 @@ uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
 version = "5.11.0+0"
 
 [[deps.libzip_jll]]
-deps = ["Artifacts", "Bzip2_jll", "GnuTLS_jll", "JLLWrappers", "Libdl", "XZ_jll", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "668ac0297e6bd8f4d53dfdcd3ace71f2e00f4a35"
+deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "OpenSSL_jll", "XZ_jll", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "e797fa066eba69f4c0585ffbd81bc780b5118ce2"
 uuid = "337d8026-41b4-5cde-a456-74a10e5b31d1"
-version = "1.11.1+0"
+version = "1.11.2+0"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
-version = "1.52.0+1"
+version = "1.59.0+0"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]

--- a/era5_monthly_averages_2008/OutputArtifacts.toml
+++ b/era5_monthly_averages_2008/OutputArtifacts.toml
@@ -1,12 +1,12 @@
 [era5_monthly_averages_2008]
-git-tree-sha1 = "c34bbd18a9fd59fd0cd48d1737705255805ab233"
+git-tree-sha1 = "a7576792b10e011c3675c1a55be88de62d91a5cb"
 
     [[era5_monthly_averages_2008.download]]
-    sha256 = "2e6a6e877122bd5a81842f8e753fd6774c29a2dc846cdd97da73e3141a38c3e2"
+    sha256 = "140950072c62d7b2f3543e13418fb1e2e9fe432f6b24fd09c52961ffc9259a84"
     url = "https://caltech.box.com/shared/static/lra5npgeygoi0xb376hi4blik44550u0.gz"
 [era5_monthly_averages_2008_hourly]
-git-tree-sha1 = "8c35843700d5517c66168d9405b351ddf3c3f79d"
+git-tree-sha1 = "b3e43da9a4d245eb80d02e0d65c9305eb9a9fc2a"
 
     [[era5_monthly_averages_2008_hourly.download]]
-    sha256 = "456d9524c018da96b3560461b016edad23adea2a8e9a4e597131777d56e2e215"
+    sha256 = "ce9a673937341b37178a49882a79e911a9ceac278bc6395fc78284951ec7705e"
     url = "https://caltech.box.com/shared/static/32625532ecl6ft3bzuu66pzwyj4dxqvn.gz"

--- a/era5_monthly_averages_2008/create_artifact.jl
+++ b/era5_monthly_averages_2008/create_artifact.jl
@@ -2,10 +2,10 @@ using Downloads
 using ClimaArtifactsHelper
 include("subset_of_data.jl")
 
-const DOWNLOAD_FILE_NAME = "era5_monthly_averages_200801-200812.nc"
+const DOWNLOAD_FILE_NAME = "era5_surface_fluxes_monthly_200801-200812.nc"
 
-const OUTPUT_FILE_HOURLY_NAME = "era5_monthly_averages_hourly_200801-200812.nc"
-const OUTPUT_FILE_NAME = "era5_monthly_averages_200801-200812.nc"
+const OUTPUT_FILE_HOURLY_NAME = "era5_monthly_surface_fluxes_hourly_200801-200812.nc"
+const OUTPUT_FILE_NAME = "era5_monthly_surface_fluxes_200801-200812.nc"
 
 # create two artifacts in two folders
 output_dir = basename(@__DIR__) * "_artifact"

--- a/era5_monthly_averages_2008/subset_of_data.jl
+++ b/era5_monthly_averages_2008/subset_of_data.jl
@@ -49,7 +49,7 @@ function create_new_ds_from_time_indx(
                 Float32.(reverse(var[:, :, time_indx], dims = 2)),
                 dimnames(var);
                 attrib = attrib,
-                deflatelevel = 9,
+                deflatelevel = 1,
             )
         end
     end
@@ -69,7 +69,7 @@ function create_new_ds_from_time_indx(
             "units" => "W m**-2",
             "long_name" => "Mean surface upward long-wave radiation flux",
         ),
-        deflatelevel = 9,
+        deflatelevel = 1,
     )
     defVar(
         output_ds,
@@ -86,7 +86,7 @@ function create_new_ds_from_time_indx(
             "units" => "W m**-2",
             "long_name" => "Mean surface upward short-wave radiation flux",
         ),
-        deflatelevel = 9,
+        deflatelevel = 1,
     )
     # convert time to standard
     new_times = map(input_ds["time"][time_indx]) do t

--- a/era5_monthly_averages_pressure_levels_1979_2024/Manifest.toml
+++ b/era5_monthly_averages_pressure_levels_1979_2024/Manifest.toml
@@ -47,7 +47,7 @@ version = "0.1.3"
 
 [[deps.ClimaArtifactsHelper]]
 deps = ["ArtifactUtils", "Downloads", "Pkg", "REPL", "SHA"]
-path = "/home/treddy/.julia/dev/ClimaArtifacts/ClimaArtifactsHelper.jl"
+path = "../ClimaArtifactsHelper.jl"
 uuid = "6ffa2572-8378-4377-82eb-ea11db28b255"
 version = "0.0.1"
 

--- a/era5_monthly_averages_pressure_levels_1979_2024/create_artifact.jl
+++ b/era5_monthly_averages_pressure_levels_1979_2024/create_artifact.jl
@@ -54,7 +54,7 @@ ignored_attribs =
     ["_FillValue", "missing_value", "add_offset", "scale_factor", "coordinates"]
 
 
-deflatelevel = 9 # max compression (lossless)
+deflatelevel = 0
 for (varname, var) in input_ds
     if !(varname in ["longitude", "latitude", "date", "pressure_level", "number", "expver"])
         attrib = copy(var.attrib)

--- a/era5_monthly_averages_single_level_1979_2024/Manifest.toml
+++ b/era5_monthly_averages_single_level_1979_2024/Manifest.toml
@@ -47,7 +47,7 @@ version = "0.1.3"
 
 [[deps.ClimaArtifactsHelper]]
 deps = ["ArtifactUtils", "Downloads", "Pkg", "REPL", "SHA"]
-path = "/home/treddy/.julia/dev/ClimaArtifacts/ClimaArtifactsHelper.jl"
+path = "../ClimaArtifactsHelper.jl"
 uuid = "6ffa2572-8378-4377-82eb-ea11db28b255"
 version = "0.0.1"
 

--- a/era5_monthly_averages_single_level_1979_2024/OutputArtifacts.toml
+++ b/era5_monthly_averages_single_level_1979_2024/OutputArtifacts.toml
@@ -1,16 +1,15 @@
 [era5_monthly_averages_surface_single_level_1979_2024]
-git-tree-sha1 = "6426ef492fdc8012c8e83427f4e45f1cda60f553"
+git-tree-sha1 = "590889f1df879b693bda0c50ed425b86b54c1831"
 
     [[era5_monthly_averages_surface_single_level_1979_2024.download]]
-    sha256 = "cff72f30dac24504bcc3b8210d3b23e543ff05dc0448d7e3b1ee141654707ac3"
+    sha256 = "2e0870587f6740c7a0da2030b2880df77f33fa15bcd19f2ca2a8190eae3d62ee"
     url = "https://caltech.box.com/shared/static/jbgtyt6oq9lxvk8il5zzck6k581q7f3k.gz"
 [era5_monthly_averages_atmos_single_level_1979_2024]
-git-tree-sha1 = "7fac017b817bb2e26da98bc54b6b3a36ab523a6a"
+git-tree-sha1 = "bbcf216993ee6a433247099d9bfe06d6b4dcd377"
 
     [[era5_monthly_averages_atmos_single_level_1979_2024.download]]
-    sha256 = "c7e61c9714fc6e1db67fdd81f8821704b619514c2143bed621345ccf4bb724e5"
+    sha256 = "fe022a8a5bfe7e65f208f561008c9f24e6a45f18a13243143db62411d37cc809"
     url = "https://caltech.box.com/shared/static/8mo7azrz0gukdtmo2oi0dtvdt1v3t3tv.gz"
-
 [era5_monthly_averages_surface_single_level_1979_2024_hourly]
 git-tree-sha1 = "6f44bae3ff1d9734b0c5a1d7417ebd52ff5aca53"
 [era5_monthly_averages_atmos_single_level_1979_2024_hourly]

--- a/era5_monthly_averages_single_level_1979_2024/process_downloads.jl
+++ b/era5_monthly_averages_single_level_1979_2024/process_downloads.jl
@@ -54,7 +54,7 @@ function create_monthly_ds_surface(input_ds, output_path)
                 Float32.(reverse(var[:, :, :], dims = 2)),
                 (dimnames(var)[1:2]..., "time");
                 attrib = attrib,
-                deflatelevel = 9,
+                deflatelevel = 1,
             )
         end
     end
@@ -79,7 +79,7 @@ function create_monthly_ds_surface(input_ds, output_path)
             "units" => "W m**-2",
             "long_name" => "Mean surface upward long-wave radiation flux",
         ),
-        deflatelevel = 9,
+        deflatelevel = 1,
     )
     defVar(
         output_ds,
@@ -95,7 +95,7 @@ function create_monthly_ds_surface(input_ds, output_path)
             "units" => "W m**-2",
             "long_name" => "Mean surface upward short-wave radiation flux",
         ),
-        deflatelevel = 9,
+        deflatelevel = 1,
     )
 
     defVar(
@@ -172,7 +172,7 @@ function create_monthly_ds_atmos(input_ds, output_path)
         Float32.(reverse(var[:, :, :], dims = 2)),
         (dimnames(var)[1:2]..., "time");
         attrib = attrib,
-        deflatelevel = 9,
+        deflatelevel = 0,
     )
 
 
@@ -247,7 +247,7 @@ function process_hourly_data_surface(input_ds, output_path)
         end
     end
     ignored_attribs = ["_FillValue", "missing_value", "add_offset", "scale_factor"]
-    deflatelevel = 9
+    deflatelevel = 0
     for (varname, var) in input_ds
         if !(
             varname in [
@@ -369,7 +369,7 @@ function process_hourly_data_atmos(input_ds, output_path)
         end
     end
     ignored_attribs = ["_FillValue", "missing_value", "add_offset", "scale_factor"]
-    deflatelevel = 9
+    deflatelevel = 0
     var = input_ds["tcw"]
     attrib = copy(var.attrib)
     for attrib_name in ignored_attribs


### PR DESCRIPTION
<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

Reduces compression levels in era5_monthly_averages_2008, era5_monthly_averages_pressure_levels_1979_2024, and  era5_monthly_averages_single_level_1979_2024. The compression level was determined using a script that profiles the size of the dataset at each compression level, and the time it takes to read a variable. 

Closes #85 
