### PR TITLE
Update artifact to get forty years of ERA5 data

### DIFF
--- a/forty_yrs_era5_land_forcing_data/Manifest.toml
+++ b/forty_yrs_era5_land_forcing_data/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.1"
+julia_version = "1.11.3"
 manifest_format = "2.0"
 project_hash = "2f6cd22eb0855fe19451904a00cf004898ee4881"
 
@@ -47,7 +47,7 @@ version = "0.1.3"
 
 [[deps.ClimaArtifactsHelper]]
 deps = ["ArtifactUtils", "Downloads", "Pkg", "REPL", "SHA"]
-path = "/home/kphan2/.julia/dev/ClimaArtifacts/ClimaArtifactsHelper.jl"
+path = "../ClimaArtifactsHelper.jl"
 uuid = "6ffa2572-8378-4377-82eb-ea11db28b255"
 version = "0.0.1"
 

--- a/forty_yrs_era5_land_forcing_data/combine_rate_and_inst.jl
+++ b/forty_yrs_era5_land_forcing_data/combine_rate_and_inst.jl
@@ -44,16 +44,19 @@ function combine_rate_and_inst(output_filepath, rate_filepath, inst_filepath)
     ncexpver[:] = Array(nc_rate["expver"])
 
     # Save all rate variables
-    rate_var_names = ["msr", "msdrswrf", "msdwlwrf", "msdwswrf", "mtpr"]
-    for var_name in rate_var_names
+    # When downloading the data, the names of the variables are now those in curr_rate_var_names
+    # We rename the variables to maintain compatibility with the ClimaLand simulations
+    curr_rate_var_names = ["avg_tsrwe", "avg_sdirswrf", "avg_sdlwrf", "avg_sdswrf", "avg_tprate"]
+    desired_rate_var_names = ["msr", "msdrswrf", "msdwlwrf", "msdwswrf", "mtpr"]
+    for (curr_var_name, desired_var_name) in zip(curr_rate_var_names, desired_rate_var_names)
         defVar(
             ds,
-            var_name,
+            desired_var_name,
             Float32,
             ("longitude", "latitude", "valid_time"),
-            attrib = nc_rate[var_name].attrib,
+            attrib = nc_rate[curr_var_name].attrib,
         )
-        ds[var_name][:, :, :] = nc_rate[var_name][:, :, :]
+        ds[desired_var_name][:, :, :] = nc_rate[curr_var_name][:, :, :]
     end
 
     # Save all inst variables

--- a/forty_yrs_era5_land_forcing_data/find_corrupted_and_missing_nc_files.jl
+++ b/forty_yrs_era5_land_forcing_data/find_corrupted_and_missing_nc_files.jl
@@ -72,7 +72,7 @@ function find_corrupted_and_missing_nc_files(first_year, last_year, last_month)
                 end
             else
                 # Data should contain only rate variables
-                if !issubset(["msr", "msdrswrf", "msdwlwrf", "msdwswrf", "mtpr"], attribs)
+                if !issubset(["avg_tsrwe", "avg_sdirswrf", "avg_sdlwrf", "avg_sdswrf", "avg_tprate"], attribs)
                     println("$file is corrupted; does not contain all the variables")
                     close(ds)
                     continue

--- a/forty_yrs_era5_land_forcing_data/get_era5_land_forcing_data.py
+++ b/forty_yrs_era5_land_forcing_data/get_era5_land_forcing_data.py
@@ -12,11 +12,13 @@ import os.path
 import os
 import shutil
 
-def get_era5_forcing_data_for(YOUR_API_KEY, year, months):
+from unzip_era5_data import unzip_era_5_files
+
+def get_era5_forcing_data_for(YOUR_API_KEY, year, months, res):
     """Get the ERA5 forcing data for ClimaLand for `months` from `year`."""
     # Make file path from year and months
     first_month = months[0]
-    filename = f"era5_forcing_data_{year}_{first_month}.nc"
+    filename = f"era5_forcing_data_{year}_{first_month}.zip"
 
     dirpath = f"era_5_{year}"
     try:
@@ -36,8 +38,8 @@ def get_era5_forcing_data_for(YOUR_API_KEY, year, months):
         print(f"{filepath} already exists; will not request data")
         return None
 
-    filename_inst = f"era5_forcing_data_{year}_{first_month}_inst.nc"
-    filename_rate = f"era5_forcing_data_{year}_{first_month}_rate.nc"
+    filename_inst = f"era5_forcing_data_{year}_{first_month}_inst.zip"
+    filename_rate = f"era5_forcing_data_{year}_{first_month}_rate.zip"
     filepath_inst = os.path.join(dirpath, filename_inst)
     filepath_rate = os.path.join(dirpath, filename_rate)
     if os.path.isfile(filepath_inst) and os.path.isfile(filepath_rate):
@@ -88,107 +90,10 @@ def get_era5_forcing_data_for(YOUR_API_KEY, year, months):
     ],
     "data_format": "netcdf",
     "download_format": "unarchived",
-    'grid'  : [1.0, 1.0]
+    'grid'  : [res, res]
 }
     client = cdsapi.Client(url="https://cds.climate.copernicus.eu/api", key=YOUR_API_KEY)
     result = client.retrieve(dataset, request, filepath)
-    return None
-
-def get_era5_forcing_split_data_for(YOUR_API_KEY, year, months):
-    """Get the ERA5 forcing data for ClimaLand for `months` from `year`, where
-    the rate and instantaneous variables are downloaded separately"""
-    # Make file path from year and months
-    first_month = months[0]
-    filename = f"era5_forcing_data_{year}_{first_month}.nc"
-    filename_inst = f"era5_forcing_data_{year}_{first_month}_inst.nc"
-    filename_rate = f"era5_forcing_data_{year}_{first_month}_rate.nc"
-
-    dirpath = f"era_5_{year}"
-    try:
-        os.mkdir(dirpath)
-        print(f"Directory '{directory_name}' created successfully.")
-    except FileExistsError:
-        print(f"Directory '{dirpath}' already exists.")
-    except PermissionError:
-        print(f"Permission denied: Unable to create '{dirpath}'.")
-    except Exception as e:
-        print(f"An error occurred: {e}")
-
-    filepath = os.path.join(dirpath, filename)
-    filepath_inst = os.path.join(dirpath, filename_inst)
-    filepath_rate = os.path.join(dirpath, filename_rate)
-
-    # If file exists, exit and do not make request
-    if os.path.isfile(filepath):
-        print(f"{filepath} already exists; will not request data")
-        return None
-
-    get_rate_data = True
-    get_inst_data = True
-
-    if os.path.isfile(filepath_rate):
-        print(f"{filepath_rate} already exists; will not request data")
-        get_rate_data = False
-    if os.path.isfile(filepath_inst):
-        print(f"{filepath_inst} already exists; will not request data")
-        get_inst_data = False
-
-    dataset = "reanalysis-era5-single-levels"
-    request_inst = {
-    "product_type": ["reanalysis"],
-    "variable": [
-        "10m_u_component_of_wind",
-        "10m_v_component_of_wind",
-        "2m_dewpoint_temperature",
-        "2m_temperature",
-        "surface_pressure",
-        "leaf_area_index_high_vegetation",
-        "leaf_area_index_low_vegetation"
-    ],
-    "year": [year],
-    "month": months,
-    "day": [
-        "01", "02", "03",
-        "04", "05", "06",
-        "07", "08", "09",
-        "10", "11", "12",
-        "13", "14", "15",
-        "16", "17", "18",
-        "19", "20", "21",
-        "22", "23", "24",
-        "25", "26", "27",
-        "28", "29", "30",
-        "31"
-    ],
-    "time": [
-        "00:00", "01:00", "02:00",
-        "03:00", "04:00", "05:00",
-        "06:00", "07:00", "08:00",
-        "09:00", "10:00", "11:00",
-        "12:00", "13:00", "14:00",
-        "15:00", "16:00", "17:00",
-        "18:00", "19:00", "20:00",
-        "21:00", "22:00", "23:00"
-    ],
-    "data_format": "netcdf",
-    "download_format": "unarchived",
-    'grid'  : [1.0, 1.0]
-}
-
-    if get_inst_data:
-        client_inst = cdsapi.Client(url="https://cds.climate.copernicus.eu/api", key=YOUR_API_KEY)
-        result_inst = client_inst.retrieve(dataset, request_inst, filepath_inst)
-
-    request_rate = copy.deepcopy(request_inst)
-    request_rate["variable"] = ["mean_snowfall_rate",
-        "mean_surface_direct_short_wave_radiation_flux",
-        "mean_surface_downward_long_wave_radiation_flux",
-        "mean_surface_downward_short_wave_radiation_flux",
-        "mean_total_precipitation_rate"]
-
-    if get_rate_data:
-        client_rate = cdsapi.Client(url="https://cds.climate.copernicus.eu/api", key=YOUR_API_KEY)
-        result_rate = client_rate.retrieve(dataset, request_rate, filepath_rate)
     return None
 
 def find_remaining_files(path, year_begin, year_end):
@@ -206,7 +111,7 @@ def find_remaining_files(path, year_begin, year_end):
     files_to_get = []
     for (year, dirpath) in zip(range(int(year_begin), int(year_end)), dirpaths):
         for month in ["01", "02", "03", "04", "05", "06", "07", "08", "09", "10", "11", "12"]:
-            files_to_get.append(os.path.join(dirpath, f"era5_forcing_data_{year}_{month}.nc"))
+            files_to_get.append(os.path.join(dirpath, f"era5_forcing_data_{year}_{month}.zip"))
 
     # Find the files we can remove
     files_to_remove = []
@@ -214,7 +119,7 @@ def find_remaining_files(path, year_begin, year_end):
         if existing_file in files_to_get:
             files_to_remove.append(existing_file)
         else:
-            if existing_file.endswith("_inst.nc") and existing_file.replace("inst", "rate") in existing_files:
+            if existing_file.endswith("_inst.zip") and existing_file.replace("inst", "rate") in existing_files:
                 files_to_remove.append(existing_file.replace("_inst", ""))
     remaining_files = filter(lambda file: file not in files_to_remove, files_to_get)
     return list(remaining_files)
@@ -223,7 +128,7 @@ if __name__ == "__main__":
     API_KEY = str(sys.argv[1])
     year_begin = str(sys.argv[2])
     year_end = str(sys.argv[3])
-    mode = str(sys.argv[4]) # could be "all" or "split"
+    res = float(sys.argv[4])
 
     print(f"API_KEY: {API_KEY}")
 
@@ -232,11 +137,13 @@ if __name__ == "__main__":
     free_space_in_GB = stat.free / (1024**3) # convert from bytes to GB
 
     # Find size of remaining files we need to download
-    # One year is approximately 8.4GB
-    required_space_in_GB = len(find_remaining_files(path, year_begin, year_end)) * (8.4 / 12.0)
+    # One year is approximately 8.4GB for 1.0 degree resolution
+    correction_factor = 1 / res**2
+    required_space_in_GB = len(find_remaining_files(path, year_begin, year_end)) * ((8.4 * correction_factor) / 12.0)
 
     if free_space_in_GB < required_space_in_GB:
         print(f"Insufficient space, free space: {free_space_in_GB} GB and required space: {required_space_in_GB} GB")
+        sys.exit()
 
     # Split the requests over all the months and submit them all at once; otherwise, we get the
     # error: Your request is too large, please reduce your selection.
@@ -261,12 +168,7 @@ if __name__ == "__main__":
     # deleting requests (see this [issue](https://github.com/ecmwf/cdsapi/issues/123)). To ensure
     # a request is always being processed, one can manually delete completed requests.
     # "all" is for downloading all the variables in one dataset
-    if mode == "all":
-        with concurrent.futures.ProcessPoolExecutor(max_workers = 144) as executor:
-            executor.map(get_era5_forcing_data_for, repeat(API_KEY), years, months)
+    with concurrent.futures.ProcessPoolExecutor(max_workers = 144) as executor:
+        executor.map(get_era5_forcing_data_for, repeat(API_KEY), years, months, repeat(res))
 
-    # "split" is for downloading the rate and instantaneous variables separately
-    # This is helpful when there are errors in downloading the variables together
-    if mode == "split":
-        with concurrent.futures.ProcessPoolExecutor(max_workers = 144) as executor:
-            executor.map(get_era5_forcing_split_data_for, repeat(API_KEY), years, months)
+    unzip_era_5_files()

--- a/forty_yrs_era5_land_forcing_data/thin_and_postprocess_artifact.jl
+++ b/forty_yrs_era5_land_forcing_data/thin_and_postprocess_artifact.jl
@@ -1,6 +1,8 @@
 """
-   postprocess_artifact(ncin, fileout)
-
+   thin_and_postprocess_artifact(
+       ncin,
+       fileout,
+   )
 Take a `ncin` ,a .nc file loaded using NCDatasets, and write a postprocessed thinned-down
 version to `fileout`.
 
@@ -17,12 +19,12 @@ Postprocessing includes:
 - All variables are stored as Float32 except for the time dimension which is stored as Int32
   (these are converted to dates when loading them in Julia).
 """
-function postprocess_artifact(ncin, fileout)
+function thin_and_postprocess_artifact(ncin, fileout)
     global_attrib = OrderedDict(ncin.attrib)
     curr_history = global_attrib["history"]
     new_history =
         curr_history *
-        "; Modified by CliMA for use in ClimaLand models (see forty_yrs_era5_land_forcing_data folder in ClimaArtifacts for full changes)"
+        "; Modified by CliMA for use in ClimaLand models (see era5_land_forcing_data2008 folder in ClimaArtifacts for full changes)"
     global_attrib["history"] = new_history
     ncout = NCDataset(fileout, "c", attrib = global_attrib)
 

--- a/forty_yrs_era5_land_forcing_data/unzip_era5_data.py
+++ b/forty_yrs_era5_land_forcing_data/unzip_era5_data.py
@@ -1,0 +1,33 @@
+import zipfile
+import os
+
+def unzip_era_5_files():
+    # Get all directories starting eith era_5_*
+    era_5_dirs = []
+    for (_, dirs, _) in os.walk("."):
+        for directory in dirs:
+            if directory.startswith("era_5"):
+                era_5_dirs.append(directory)
+    # Get all the files in the directory in a list
+    for directory in era_5_dirs:
+        # Get all files
+        only_files = [os.path.join(directory, f) for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]
+
+        # Filter to get zip files whose names start with "era_5_focing_data_"
+        only_zips = [f for f in only_files if os.path.basename(f).startswith("era5_forcing_data") and os.path.basename(f).endswith(".zip")]
+        for zip_file in only_zips:
+            # Get the file name excluding .zip at the end
+            file_name_without_zip = zip_file[:-4]
+            zipdata = zipfile.ZipFile(zip_file)
+            zipinfos = zipdata.infolist()
+            for zipinfo in zipinfos:
+                file_name = zipinfo.filename
+                # Rename files extracted
+                if "avg" in file_name:
+                    desired_file_name = file_name_without_zip + "_rate.nc"
+                elif "instant" in file_name:
+                    desired_file_name = file_name_without_zip + "_inst.nc"
+                else:
+                    raise FileExistsError("A file exists in the zip file that is not expected!")
+                zipinfo.filename = desired_file_name
+                zipdata.extract(zipinfo)


### PR DESCRIPTION
I made the following updates to the artifact:
1. Add code to unzip and rename files due to changes in the Copernicus backend.
2. Change Manifest.toml to use a relative path for ClimaArtifactsHelper.jl.
3. Remove functionality to download rate and instantaneous variables separately. This is because the Copernicus backend fixed the issue of variables not being downloaded by forcing the rate and instantaneous variables to be downloaded separately.
4. Add renaming of rate variables to the names before the change to the Copernicus backend to maintain backward compatibility  with ClimaLand.

