### PR TITLE
Add relative humidity to era5_cloud

### DIFF
--- a/era5_cloud/OutputArtifacts.toml
+++ b/era5_cloud/OutputArtifacts.toml
@@ -1,8 +1,8 @@
 [era5_cloud]
 git-tree-sha1 = "8bad412ada94be95a2e11c794b499c49d746be50"
 [era5_cloud_lowres]
-git-tree-sha1 = "b42adb958f0b2ba34194e5f5440753be5bb4dc34"
+git-tree-sha1 = "258a2626b6008bf2f926b2711f8cb5273edc3916"
 
     [[era5_cloud_lowres.download]]
-    sha256 = "469d656f94f6e168c559399f9941e09cd16bc47d6fea3de44b511842ba7137b1"
+    sha256 = "c1d29e996fcdc0c263f8b54ca1ddd858c46326fc4cfc3ab3dc71e5e598322de8"
     url = "https://caltech.box.com/shared/static/lr9k1s2pgeqzli8goxq9y2liiy3u6kni.gz"

--- a/era5_cloud/README.md
+++ b/era5_cloud/README.md
@@ -1,12 +1,12 @@
 # Cloud data, hourly, 2010
 
-This artifact repackages data coming from [ERA5 reanalysis](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-pressure-levels?tab=overview) 
+This artifact repackages data coming from [ERA5 reanalysis](https://cds.climate.copernicus.eu/datasets/reanalysis-era5-pressure-levels?tab=overview)
 and contains hourly cloud properties in 2010.
 
 The input file is defined in pressure coordinates. We convert this into altitude over mean-sea level
-using $P = P^*exp(-z / H)$ with scale height $H$. We assume $P^* = 1e5$ (Pa) and $H = 7000$ (m). The output 
+using $P = P^*exp(-z / H)$ with scale height $H$. We assume $P^* = 1e5$ (Pa) and $H = 7000$ (m). The output
 is a NetCDF file that contains cloud fraction, cloud liquid water content (kg/kg), cloud ice water content (kg/kg),
-and specific humidity (kg/kg) defined on a lon-lat-z-time grid.
+and specific humidity (kg/kg), and relative humidity (ratio) defined on a lon-lat-z-time grid.
 
 ## Usage
 To recreate the artifact:

--- a/era5_cloud/download_era5.py
+++ b/era5_cloud/download_era5.py
@@ -59,7 +59,7 @@ def download_era5(variable, month):
 
 if __name__ == "__main__":
     variables = ["fraction_of_cloud_cover", "specific_cloud_ice_water_content",
-                "specific_cloud_liquid_water_content", "specific_humidity"]
+                "specific_cloud_liquid_water_content", "specific_humidity", "relative_humidity"]
     months = list(map(lambda x: str(x).zfill(2), range(1, 13)))
     variables_all = [r[0] for r in itertools.product(variables, months)]
     months_all = [r[1] for r in itertools.product(variables, months)]


### PR DESCRIPTION
Adds relative humidity to both the era5_cloud era5_cloud_lowres artifacts.

Accompanying ClimaAtmos [PR](https://github.com/CliMA/ClimaAtmos.jl/pull/3619) 

Checklist:
- [x] I created a new folder `$artifact_name`
  - [x] I added a `README.md` in that that folder that
    - [x] describes the data and processing done to it
    - [x] lists the sources of the raw data
    - [x] lists the required citation, licenses
  - [x] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [x] I added the scripts that retrieve, process, and produce the artifact
  - [x] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [x] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [x] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [x] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [x] I added a link to the main `README.md` to point to the new artifact

