### PR TITLE
Add additional years of MODIS LAI data (2000-2020)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ artifacts.
 - [Soil parameters needed for Richards equation; global at 1km resolution from
 S. Gupta et al 2022, 2024](https://github.com/CliMA/ClimaArtifacts/tree/main/soil_params_Gupta2020_2022)
 - [Foliage clumping index, derived from MODIS data for 2006](https:////github.com/CliMA/ClimaArtifacts/tree/main/modis_clumping_index)
-- [Leaf area index, derived from MODIS data for 2008](https:////github.com/CliMA/ClimaArtifacts/tree/main/modis_lai)
+- [Leaf area index, derived from MODIS data for 2000-2020](https:////github.com/CliMA/ClimaArtifacts/tree/main/modis_lai)
 - [Subset of ILAMB datasets](https:////github.com/CliMA/ClimaArtifacts/tree/main/ilamb_data)
 - [Bonan 2019 Richards equation data](https:////github.com/CliMA/ClimaArtifacts/tree/main/bonan_richards_eqn)
 - [TwoStream model implementation test data](https:////github.com/CliMA/ClimaArtifacts/tree/main/twostr_test)

--- a/modis_lai/OutputArtifacts.toml
+++ b/modis_lai/OutputArtifacts.toml
@@ -1,6 +1,6 @@
 [modis_lai]
-git-tree-sha1 = "20ee5dc96fde9a15bd3c40e80ac5036a9a39e0cf"
+git-tree-sha1 = "81d4bc1b22e94d66eec3d80a2d21b5dd5303bf8f"
 
     [[modis_lai.download]]
-    sha256 = "e97bf4a8eeac7c32c00a7d27bf5ec957e9c800117d56e66c27a123171a1f1c04"
+    sha256 = "4a244428fe480aa05ff863af69299d2ed8ca66ed324b9e1bffcb440792fb4cce"
     url = "https://caltech.box.com/shared/static/99ktg026kciezykyegsawd1gjwj1du74.gz"

--- a/modis_lai/README.md
+++ b/modis_lai/README.md
@@ -1,4 +1,4 @@
-# Leaf Area Index, derived from MODIS data for 2008
+# Leaf Area Index, derived from MODIS data for 2000-2020
 
 This artifact repackages data coming from:
 Hua Yuan, Yongjiu Dai, Zhiqiang Xiao, Duoying Ji, Wei Shangguan,Reprocessing the MODIS Leaf Area Index products for land surface and climate modelling, Remote Sensing of Environment, Volume 115, Issue 5, 2011, Pages 1171-1187, ISSN 0034-4257, https://doi.org/10.1016/j.rse.2011.01.001.
@@ -11,5 +11,7 @@ We regrid the data to 1 degree resolution, and output a netCDF file with the fol
   - `lat`  : Latitude, degrees north
   - `lon`  : Longitude, degrees east
   - `month`: Month of the year, in `DateTime` format
+
+for each year from 2000-2020
 
 License: Creative Commons Zero

--- a/modis_lai/create_artifacts.jl
+++ b/modis_lai/create_artifacts.jl
@@ -28,16 +28,23 @@ using ClimaArtifactsHelper
 ################################################################################
 
 # Dataset to be fetched via the GriddingMachine
-MODIS_LAI_DATASET = "MODIS_2X_1M_2008_V1"
+MODIS_LAI_DATASET_PREFIX = "MODIS_2X_1M_"
+MODIS_LAI_DATASET_SUFFIX = "_V1"
 
 # Output directory
 OUTPUT_DIR = "modis_lai"
 
 # Output nc file name
-OUTPUT_FILE = "Yuan_et_al_2011_1x1.nc"
+OUTPUT_FILE_PREFIX = "Yuan_et_al_"
 
-# Resolution of the simulation
+# Output nc file name suffix
+OUTPUT_FILE_SUFFIX = "_1x1.nc"
+
+# Output data resolution
 RESOLUTION = 1
+
+# Years to fetch
+YEARS = range(2000, 2020)
 
 ################################################################################
 # MAIN                                                                         #
@@ -51,71 +58,86 @@ else
     mkdir(OUTPUT_DIR)
 end
 
-# Download the LAI data as a julia artifact.
-lai_collector  = Collector.lai_collection()
-download_path = Collector.query_collection(lai_collector, MODIS_LAI_DATASET)
+for year in YEARS
+    # Dataset to be fetched via the GriddingMachine
+    MODIS_LAI_DATASET = MODIS_LAI_DATASET_PREFIX * string(year) *
+                         MODIS_LAI_DATASET_SUFFIX
 
-# Read the data from the dowloaded nc file
-lai_data = Indexer.read_LUT(download_path)
+    # Output nc file name
+    OUTPUT_FILE = OUTPUT_FILE_PREFIX * string(year) * OUTPUT_FILE_SUFFIX
 
-# Regrid the data to the desired simulation resolution - 1x1 degree. Note that 
-# the regridder will require integer trucation of the divider (1/R)
-lai_data_regridded = Blender.regrid(lai_data[1], Int64(1 / RESOLUTION))
+    # Download the LAI data as a julia artifact.
+    lai_collector  = Collector.lai_collection()
+    download_path = Collector.query_collection(lai_collector, MODIS_LAI_DATASET)
 
-# Get the original the lat/lon vectors of the dataset so that we may compute the
-# lat/lon of the regridded data.
-orig_data = NCDataset(download_path, "r")
-orig_lat = orig_data["lat"][:]
-orig_lon = orig_data["lon"][:]
-close(orig_data)
+    # Read the data from the dowloaded nc file
+    lai_data = Indexer.read_LUT(download_path)
 
-# Convert all NANs in the data to 0.0 (i.e, LAI should be 0 over the ocean)
-lai_data_regridded .= ifelse.(isnan.(lai_data_regridded), 0.0f0,
+    # Regrid the data to the desired simulation resolution - 1x1 degree. Note
+    # that the regridder will require integer trucation of the divider (1/R)
+    lai_data_regridded = Blender.regrid(lai_data[1], Int64(1 / RESOLUTION))
+
+    # Get the original the lat/lon vectors of the dataset so that we may compute
+    # the lat/lon of the regridded data.
+    orig_data = NCDataset(download_path, "r")
+    orig_lat = orig_data["lat"][:]
+    orig_lon = orig_data["lon"][:]
+    close(orig_data)
+
+    # Convert all NANs in the data to 0.0 (i.e, LAI should be 0 over the ocean)
+    lai_data_regridded .= ifelse.(isnan.(lai_data_regridded), 0.0f0,
                                                              lai_data_regridded)
 
-# Since we regridded to half of the resolution of the original data, we need to 
-# average every 2 lat/lon points to get the lat/lon of the regridded data.
-out_lon = (orig_lon[1:2:end] .+ orig_lon[2:2:end]) ./ 2
-out_lat = (orig_lat[1:2:end] .+ orig_lat[2:2:end]) ./ 2
+    # Since we regridded to half of the resolution of the original data, we need
+    # to average every 2 lat/lon points to get the lat/lon of the regridded
+    # data.
+    out_lon = (orig_lon[1:2:end] .+ orig_lon[2:2:end]) ./ 2
+    out_lat = (orig_lat[1:2:end] .+ orig_lat[2:2:end]) ./ 2
 
-# Write the regridded data to the output directory
-output_path = joinpath(OUTPUT_DIR, OUTPUT_FILE)
-ds          = NCDataset(output_path, "c")
+    # Write the regridded data to the output directory
+    output_path = joinpath(OUTPUT_DIR, OUTPUT_FILE)
+    ds          = NCDataset(output_path, "c")
 
-# Define the dimensions of the data -> 2D spatially varying data over 12 months
-defDim(ds, "lon", size(lai_data_regridded)[1])
-defDim(ds, "lat", size(lai_data_regridded)[2])
-defDim(ds, "time", 12)
+    # Define the dimensions of the data -> 2D spatially varying data over 12
+    # months
+    defDim(ds, "lon", size(lai_data_regridded)[1])
+    defDim(ds, "lat", size(lai_data_regridded)[2])
+    defDim(ds, "time", 12)
 
-# Define the variables of the data - lat, lon, and the lai
-la      = defVar(ds, "lat", Float32, ("lat",))
-lo      = defVar(ds, "lon", Float32, ("lon",))
-month   = defVar(ds, "time", Int32, ("time",))
-lai_var = defVar(ds, "lai", Float32, ("lon", "lat", "time"))
+    # Define the variables of the data - lat, lon, and the lai
+    la      = defVar(ds, "lat", Float32, ("lat",))
+    lo      = defVar(ds, "lon", Float32, ("lon",))
+    month   = defVar(ds, "time", Int32, ("time",))
+    lai_var = defVar(ds, "lai", Float32, ("lon", "lat", "time"))
 
-# Set the attributes of the variables.
-la.attrib["units"]             = "degrees_north"
-la.attrib["standard_name"]     = "latitude"
-lo.attrib["units"]             = "degrees_east"
-lo.attrib["standard_name"]     = "longitude"
-month.attrib["units"]          = "seconds since 1970-01-01"
-month.attrib["standard_name"]  = "time"
-month.attrib["calendar"]       = "proleptic_gregorian"
-lai_var.attrib["units"]         = "m^2 m^-2"
-lai_var.attrib["standard_name"] = "Leaf area index"
+    # Set the attributes of the variables.
+    la.attrib["units"]              = "degrees_north"
+    la.attrib["standard_name"]      = "latitude"
+    lo.attrib["units"]              = "degrees_east"
+    lo.attrib["standard_name"]      = "longitude"
+    month.attrib["units"]           = "seconds since 1970-01-01"
+    month.attrib["standard_name"]   = "time"
+    month.attrib["calendar"]        = "proleptic_gregorian"
+    lai_var.attrib["units"]         = "m^2 m^-2"
+    lai_var.attrib["standard_name"] = "Leaf area index"
 
-# Write the data for each variable out to the nc file
-la[:]     = out_lat
-lo[:]     = out_lon
-# Note that even spacing on the timestamps is required for the periodicCalendar
-# boundary condition
-times     = [DateTime(2008, 1, 1) + Dates.Day(30 * (k - 1)) for k in 1:12]
-month[:]  = Int32.([Dates.datetime2unix(t) for t in times])
-lai_var[:, :, :] = lai_data_regridded
-close(ds)
+    # Write the data for each variable out to the nc file
+    la[:]     = out_lat
+    lo[:]     = out_lon
+    
+    # Data from the gridding machhine is month (1:1:12), and we need to convert
+    # to DateTime format for the time variable so that we can use the
+    # periodicCalendar calendar boundary condition in the Land model.
+    # Note that even spacing on the timestamps is required for the
+    # periodicCalendar boundary condition
+    times     = [DateTime(year, 1, 1) + Dates.Day(30 * (k - 1)) for k in 1:12]
+    month[:]  = Int32.([Dates.datetime2unix(t) for t in times])
+    lai_var[:, :, :] = lai_data_regridded
+    close(ds)
 
-# Remove the initial downloaded artifact file - desired data is now stored in 
-# the CliMA artifact.
-Collector.clean_collections!(lai_collector)
+    # Remove the initial downloaded artifact file - desired data is now stored
+    # in the CliMA artifact.
+    Collector.clean_collections!(lai_collector)
+end
 
 create_artifact_guided(OUTPUT_DIR; artifact_name = basename(@__DIR__))


### PR DESCRIPTION
<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

This very simple PR adds MODIS LAI for years 2000-2020. Previously, we only had 2008. This is the full range of years available from the gridding machine.

Checklist:
- [x] I created a new folder `$artifact_name`
  - [x] I added a `README.md` in that that folder that
    - [x] describes the data and processing done to it
    - [x] lists the sources of the raw data
    - [x] lists the required citation, licenses
  - [x] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [x] I added the scripts that retrieve, process, and produce the artifact
  - [x] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [x] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [x] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [x] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [x] I added a link to the main `README.md` to point to the new artifact

