### PR TITLE
Update ERA5 LAI covers artifact

### DIFF
--- a/era5_lai_covers/OutputArtifacts.toml
+++ b/era5_lai_covers/OutputArtifacts.toml
@@ -1,6 +1,6 @@
 [era5_lai_covers]
-git-tree-sha1 = "dd651b30b448740bdfef8e9cb7835bcd55ddf72f"
+git-tree-sha1 = "1e77fc84a027da43f1bf6ebe0a53849595a2be22"
 
     [[era5_lai_covers.download]]
-    sha256 = "2c5bcbd0823e037c5fcd67444b2cbdd2f054906752af6e8574a2975ede7f8160"
-    url = "https://caltech.box.com/shared/static/vf5ts11u2o5yjb1jmr387audnephnftr.gz"
+    sha256 = "0331e3a2fc2cb53b0f1d9c5a84f49989da0b506258edc229da161e9ca4a61457"
+    url = "https://caltech.box.com/shared/static/uzuzk5wh8r9q477jbrusfg1sr0ytzem9.gz"

--- a/era5_lai_covers/README.md
+++ b/era5_lai_covers/README.md
@@ -26,7 +26,7 @@ to set up a CDS API personal access token.
 3. Run the script (e.g. `python get_era5_lai_covers.py).
 4. Run `julia --project=. create_artifact.jl`.
 5. After the artifact is created, you can delete the NetCDF files used to make
-   the plots.
+   the artifact.
 
 ## Post-processing
 - Updating history for global attributes.


### PR DESCRIPTION
This need to be updated because I deleted the original folder while trying to diagnose the issue with Box.

For some reason, the SHA256 changes, but I think the LAI covers downloaded from ERA5 change since the script was not modified in any way.