### PR TITLE
updated soil initial conditions using long run 4035

### DIFF
--- a/soil_ic_2008_50m/OutputArtifacts.toml
+++ b/soil_ic_2008_50m/OutputArtifacts.toml
@@ -1,6 +1,6 @@
 [soil_ic_2008_50m]
-git-tree-sha1 = "ed35be513e4073406bce6dec4a3c1f061d434410"
+git-tree-sha1 = "45257ae2f5314f721a13a0effc7a2cf602e71d2f"
 
     [[soil_ic_2008_50m.download]]
-    sha256 = "27e6e485340afc4400ebaf43fbe1258e785643658d555b555cba59eb4fc25ece"
+    sha256 = "efc107ad866656c8791622e1361f04b504282503dbea3ee760fbf4470c87195d"
     url = "https://caltech.box.com/shared/static/atiztw8uu2i78g2vd02n8onb68cer9tn.gz"


### PR DESCRIPTION
This updates the artifact for our spun up IC using https://buildkite.com/clima/climaland-long-runs/builds/4035
Checklist:
- [N/A] I created a new folder `$artifact_name`
  - [N/A] I added a `README.md` in that that folder that
    - [N/A] describes the data and processing done to it
    - [X] lists the sources of the raw data
    - [N/A] lists the required citation, licenses
  - [N/A] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [N/A] I added the scripts that retrieve, process, and produce the artifact
  - [N/A] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [X] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [X] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [X] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [N/A] I added a link to the main `README.md` to point to the new artifact

N/A: already done in previous PR adding this artifact