### PR TITLE
Create fluxnet2015 metadata

### DIFF
--- a/fluxnet2015/README.md
+++ b/fluxnet2015/README.md
@@ -1,10 +1,22 @@
 ## Description
-FLUXNET eddy covariance flux tower site data is used to validate ClimaLand on a site-level basis. The data must be manually downloaded from the FLUXNET website before running this script. **As such, the only functionality of `create_artifact.jl` is to create a hash assuming that the downloaded data is in a directory called `fluxnet2015`, then doing some metadata retrieval**. In the future, we may update this to directly download data from the remote source, but this can be cumbersome because as of now the data can only be downloaded sitewise using a web browser macro. This is an undownloadable artifact (42 GB). 
+FLUXNET eddy covariance flux tower site data is used to validate ClimaLand on a site-level basis. The data must be manually downloaded from the FLUXNET website before running this script (see Setup for how to set up this artifact locally). **As such, the only functionality of `create_artifact.jl` is to create a hash assuming that the downloaded data is in a directory called `fluxnet2015`, then doing some metadata retrieval**. In the future, we may update this to directly download data from the remote source, but this can be cumbersome because as of now the data can only be downloaded sitewise using a web browser macro. The artifact which is stored on the Caltech HPC is 42 GB and was downloaded in May 2020. 
 
 ### Postprocessing
-The only postprocessing that we do is metadata retrieval and cleaning from the FLX_AA directory. This contains site domain info as well as measurement heights. 
+The only postprocessing that we do is metadata retrieval and cleaning from the FLX_AA directory. This contains site domain info as well as measurement heights that are useful for setting up site-level simulations. Currently, we look for and compile the following variables:
+- Lat/long, UTC offset
+- Annual mean temperature and precipitation
+- Canopy height (averaged across measurements, if there are multiple)
+- Atmospheric sensor height(s)
+- Soil water sensor height(s)
+- Soil temperature sensor height(s)
 
-Individual site data can be retrieved from https://fluxnet.org/data/fluxnet2015-dataset/ 
+## Setup
+Individual site data can be retrieved from https://fluxnet.org/data/fluxnet2015-dataset/. **This artifact expects FULLSET data, as opposed to leaner subsets**. To setup the repository structure, follow these steps:
+1) Create a new repository called `fluxnet2015` 
+2) Download individual FULLSET site data, which should go in subdirectories e.g., `/fluxnet2015/FLX_US-Var_FLUXNET2015_FULLSET_2000-2014_1-4`
+3) Download the metadata files, which should go in a subdirectory, e.g., `fluxnet2015/FLX_AA-Flx_BIF_ALL_20200501`
+4) In `create_artifact.jl`, change the `METADATA_FILE_PATH` variable to point to the correct metadata path. 
+5) Run `create_artifact.jl` using `julia --project=. create_artifact.jl` and follow the instructions from the script to add the hash to your own `Overrides.toml` file.
 
 License: CC BY 4.0
 

--- a/fluxnet2015/README.md
+++ b/fluxnet2015/README.md
@@ -1,5 +1,8 @@
 ## Description
-FLUXNET eddy covariance flux tower site data is used to validate ClimaLand on a site-level basis. The data must be manually downloaded from the FLUXNET website before running this script. **As such, the only functionality of `create_artifact.jl` is to create a hash assuming that the downloaded data is in a directory called `fluxnet2015`**. In the future, we may update this to directly download data from the remote source, but this can be cumbersome because as of now the data can only be downloaded sitewise using a web browser macro. No preprocessing is done. This is an undownloadable artifact (42 GB). 
+FLUXNET eddy covariance flux tower site data is used to validate ClimaLand on a site-level basis. The data must be manually downloaded from the FLUXNET website before running this script. **As such, the only functionality of `create_artifact.jl` is to create a hash assuming that the downloaded data is in a directory called `fluxnet2015`, then doing some metadata retrieval**. In the future, we may update this to directly download data from the remote source, but this can be cumbersome because as of now the data can only be downloaded sitewise using a web browser macro. This is an undownloadable artifact (42 GB). 
+
+### Postprocessing
+The only postprocessing that we do is metadata retrieval and cleaning from the FLX_AA directory. This contains site domain info as well as measurement heights. 
 
 Individual site data can be retrieved from https://fluxnet.org/data/fluxnet2015-dataset/ 
 

--- a/fluxnet2015/create_artifact.jl
+++ b/fluxnet2015/create_artifact.jl
@@ -1,7 +1,8 @@
 """
-This file generates a hash for the existing fluxnet2015 artifact that is
-stored in the Caltech HPC cluster filesystem. As of now, there is unfortunately
-no way to reproduce the artifact from a downloadable source. 
+This file first generates a hash for the existing fluxnet2015 artifact that is
+stored in the Caltech HPC cluster filesystem, then retrieves and cleans its metadata. 
+As of now, there is unfortunately no way to reproduce the artifact from a 
+downloadable source. 
 """
 
 using ClimaArtifactsHelper
@@ -25,3 +26,8 @@ output_artifacts = "OutputArtifacts.toml"
 open(output_artifacts, "w") do file
     write(file, artifacts_str)
 end
+
+# Process metadata 
+script_path = "process_metadata.sh"
+file_path = "/groups/esm/ClimaArtifacts/artifacts/fluxnet2015/FLX_AA-Flx_BIF_ALL_20200501/FLX_AA-Flx_BIF_DD_20200501.xlsx"
+run(`bash $script_path $file_path`)

--- a/fluxnet2015/create_artifact.jl
+++ b/fluxnet2015/create_artifact.jl
@@ -10,11 +10,12 @@ using SHA
 
 artifact_name = basename(@__DIR__)
 
+METADATA_FILE_PATH = "/groups/esm/ClimaArtifacts/artifacts/fluxnet2015/FLX_AA-Flx_BIF_ALL_20200501/FLX_AA-Flx_BIF_DD_20200501.xlsx"
+
 hash = bytes2hex(sha1(artifact_name))
 artifacts_str = "[$artifact_name]\ngit-tree-sha1 = \"$hash\"\n"
 
-println("Here is your artifact string. Copy and paste it to your Artifacts.toml. Note that this artifact 
-will only be available on the Caltech HPC cluster.")
+println("Here is your artifact string. Copy and paste it to your Artifacts.toml.")
 println()
 println(artifacts_str)
 
@@ -30,5 +31,4 @@ end
 
 # Process metadata 
 script_path = "process_metadata.sh"
-file_path = "/groups/esm/ClimaArtifacts/artifacts/fluxnet2015/FLX_AA-Flx_BIF_ALL_20200501/FLX_AA-Flx_BIF_DD_20200501.xlsx"
-run(`bash $script_path $file_path`)
+run(`bash $script_path $METADATA_FILE_PATH`)

--- a/fluxnet2015/create_artifact.jl
+++ b/fluxnet2015/create_artifact.jl
@@ -6,6 +6,7 @@ downloadable source.
 """
 
 using ClimaArtifactsHelper
+using SHA
 
 artifact_name = basename(@__DIR__)
 

--- a/fluxnet2015/process_metadata.py
+++ b/fluxnet2015/process_metadata.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+import csv
+import sys
+import os
+import re
+from collections import defaultdict
+
+def process_metadata(input_csv, output_csv):
+    os.makedirs(os.path.dirname(output_csv), exist_ok=True)
+
+    key_map = {
+        "LOCATION_LAT": "latitude",
+        "LOCATION_LONG": "longitude",
+        "UTC_OFFSET": "utc_offset",
+        "HEIGHTC": "canopy_height_raw"
+    }
+
+    # Regex for SWC & TS variable detection
+    swc_pattern = re.compile(r"^SWC_F_MDS_\d+$")
+    ts_pattern = re.compile(r"^TS_F_MDS_\d+$")
+
+    sites = defaultdict(lambda: {
+        "latitude": None,
+        "longitude": None,
+        "utc_offset": None,
+        "canopy_height_values": [],
+        "atmospheric_sensor_heights": set(),
+        "swc_depths": set(),
+        "ts_depths": set()
+    })
+
+    with open(input_csv, newline='') as f:
+        rows = list(csv.reader(f))
+
+    i = 0
+    while i < len(rows):
+        row = rows[i]
+        site_id, key, value = row[0], row[3], row[4]
+
+        # Handle direct key mappings
+        if key in key_map:
+            if key == "HEIGHTC":
+                try:
+                    sites[site_id]["canopy_height_values"].append(float(value))
+                except ValueError:
+                    pass
+            else:
+                target_key = key_map[key]
+                try:
+                    sites[site_id][target_key] = float(value)
+                except ValueError:
+                    sites[site_id][target_key] = value
+
+        # Atmospheric sensor heights (CO2_F_MDS -> next row)
+        if value == "CO2_F_MDS" and i + 1 < len(rows):
+            try:
+                sites[site_id]["atmospheric_sensor_heights"].add(float(rows[i + 1][4]))
+            except ValueError:
+                pass
+
+        # Soil water content depths
+        if swc_pattern.match(value) and i + 1 < len(rows):
+            try:
+                sites[site_id]["swc_depths"].add(float(rows[i + 1][4]))
+            except ValueError:
+                pass
+
+        # Soil temperature depths
+        if ts_pattern.match(value) and i + 1 < len(rows):
+            try:
+                sites[site_id]["ts_depths"].add(float(rows[i + 1][4]))
+            except ValueError:
+                pass
+
+        i += 1
+
+    # Post-process results
+    for site_id, data in sites.items():
+        # Canopy height average
+        if data["canopy_height_values"]:
+            data["canopy_height"] = sum(data["canopy_height_values"]) / len(data["canopy_height_values"])
+        else:
+            data["canopy_height"] = None
+
+        # Convert sets to sorted lists
+        data["atmospheric_sensor_heights"] = sorted(data["atmospheric_sensor_heights"])
+        data["swc_depths"] = sorted(data["swc_depths"]) if data["swc_depths"] else ["NaN"]
+        data["ts_depths"] = sorted(data["ts_depths"]) if data["ts_depths"] else ["NaN"]
+
+    # Write minimal CSV
+    with open(output_csv, "w", newline='') as f:
+        writer = csv.writer(f)
+        writer.writerow([
+            "site_id","latitude","longitude","utc_offset",
+            "canopy_height","atmospheric_sensor_heights","swc_depths","ts_depths"
+        ])
+        for site_id, data in sites.items():
+            writer.writerow([
+                site_id,
+                data["latitude"],
+                data["longitude"],
+                data["utc_offset"],
+                data["canopy_height"],
+                ";".join(map(str, data["atmospheric_sensor_heights"])),
+                ";".join(map(str, data["swc_depths"])),
+                ";".join(map(str, data["ts_depths"]))
+            ])
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: process_fluxnet_metadata.py input_csv output_csv")
+        sys.exit(1)
+    process_metadata(sys.argv[1], sys.argv[2])

--- a/fluxnet2015/process_metadata.py
+++ b/fluxnet2015/process_metadata.py
@@ -12,7 +12,9 @@ def process_metadata(input_csv, output_csv):
         "LOCATION_LAT": "latitude",
         "LOCATION_LONG": "longitude",
         "UTC_OFFSET": "utc_offset",
-        "HEIGHTC": "canopy_height_raw"
+        "HEIGHTC": "canopy_height_raw",
+        "MAT": "annual_temp",
+        "MAP": "annual_precip",
     }
 
     # Regex for SWC & TS variable detection
@@ -23,6 +25,8 @@ def process_metadata(input_csv, output_csv):
         "latitude": None,
         "longitude": None,
         "utc_offset": None,
+        "annual_temp": None,
+        "annual_precip": None,
         "canopy_height_values": [],
         "atmospheric_sensor_heights": set(),
         "swc_depths": set(),
@@ -84,15 +88,15 @@ def process_metadata(input_csv, output_csv):
 
         # Convert sets to sorted lists
         data["atmospheric_sensor_heights"] = sorted(data["atmospheric_sensor_heights"])
-        data["swc_depths"] = sorted(data["swc_depths"]) if data["swc_depths"] else ["NaN"]
-        data["ts_depths"] = sorted(data["ts_depths"]) if data["ts_depths"] else ["NaN"]
+        data["swc_depths"] = sorted(data["swc_depths"]) if data["swc_depths"] else "NaN"
+        data["ts_depths"] = sorted(data["ts_depths"]) if data["ts_depths"] else "NaN"
 
     # Write minimal CSV
     with open(output_csv, "w", newline='') as f:
         writer = csv.writer(f)
         writer.writerow([
-            "site_id","latitude","longitude","utc_offset",
-            "canopy_height","atmospheric_sensor_heights","swc_depths","ts_depths"
+            "site_id", "latitude", "longitude", "utc_offset", "annual_temp", "annual_precip",
+            "canopy_height", "atmospheric_sensor_heights", "swc_depths", "ts_depths"
         ])
         for site_id, data in sites.items():
             writer.writerow([
@@ -100,6 +104,8 @@ def process_metadata(input_csv, output_csv):
                 data["latitude"],
                 data["longitude"],
                 data["utc_offset"],
+                data["annual_temp"],
+                data["annual_precip"],
                 data["canopy_height"],
                 ";".join(map(str, data["atmospheric_sensor_heights"])),
                 ";".join(map(str, data["swc_depths"])),

--- a/fluxnet2015/process_metadata.sh
+++ b/fluxnet2015/process_metadata.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+    echo "Please provide the path to the fluxnet2015 metadata file as an argument (ex: /path/to/FLX_AA-Flx_BIF_DD_20200501.xlsx)"
+    exit 1
+fi
+
+metadata_path="$1"
+
+# Infer parent fluxnet2015 directory
+fluxnet_dir="$(dirname "$(dirname "$metadata_path")")"
+
+# Example file name: FLX_AA-Flx_BIF_DD_20200501.xlsx
+filename="$(basename "$metadata_path")"
+temporal_code=$(echo "$filename" | awk -F'_' '{print $4}')
+
+# Ensure xlsx2csv is installed
+if ! command -v xlsx2csv >/dev/null 2>&1; then
+    echo "xlsx2csv not found. Installing..."
+    pip install --user xlsx2csv
+    export PATH="$PATH:$(python -m site --user-base)/bin"
+fi
+
+# Convert to CSV in fluxnet2015 root directory
+output_csv="$fluxnet_dir/metadata_${temporal_code}_full.csv"
+echo "Converting $metadata_path -> $output_csv"
+xlsx2csv "$metadata_path" "$output_csv"
+
+echo "Full metadata CSV saved at: $output_csv"
+
+# process the CSV 
+processed_csv="$fluxnet_dir/metadata_${temporal_code}_clean.csv"
+echo "Processing metadata to minimal CSV: $processed_csv"
+python3 "$(dirname "$0")/process_metadata.py" "$output_csv" "$processed_csv"
+
+echo "Processed metadata saved at: $processed_csv"


### PR DESCRIPTION
<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

This adds a script to process fluxnet2015 metadata which is used to retrieve domain info for setting up the land simulation. I also added some better instructions for how to set up this undownloadable artifact locally. 

Checklist:
N/A I created a new folder `$artifact_name`
  - N/A I added a `README.md` in that that folder that
    - [ ] describes the data and processing done to it
    - [ ] lists the sources of the raw data
    - [ ] lists the required citation, licenses
  - [ ] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [ ] I added the scripts that retrieve, process, and produce the artifact
  - [ ] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [ ] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [ ] I uploaded the artifact folder to the Caltech cluster (in
      `/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [ ] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [ ] I added a link to the main `README.md` to point to the new artifact

