### PR TITLE
Generate atmos target grid for wxquest_initial_conditions

### DIFF
--- a/wxquest_initial_conditions/Project.toml
+++ b/wxquest_initial_conditions/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 ClimaArtifactsHelper = "6ffa2572-8378-4377-82eb-ea11db28b255"
+NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"

--- a/wxquest_initial_conditions/create_artifact.jl
+++ b/wxquest_initial_conditions/create_artifact.jl
@@ -1,4 +1,5 @@
 using ClimaArtifactsHelper
+using NCDatasets
 
 dates_file = joinpath(@__DIR__, "dates.txt")
 output_dir = "wxquest_initial_conditions_artifact"
@@ -24,20 +25,38 @@ mktempdir(prefix="weatherquest_") do repo_dir
         @info "  $date $time"
         run(`python3 $get_ic
             --date $date --time $time
+            --atmos-levels model
             --output-dir $output_dir`)
     end
 
     @info "Instantiating WeatherQuest Julia environment..."
     run(`julia --project=$repo_dir -e "using Pkg; Pkg.instantiate()"`)
 
-    @info "Preprocessing initial conditions..."
     abs_output_dir = abspath(output_dir)
+
+    @info "Generating atmosphere target grid file..."
+    atmos_grid_file = joinpath(abs_output_dir, "atmos_grid.nc")
+    NCDataset(atmos_grid_file, "c") do ds
+        defDim(ds, "lon", 384)
+        defDim(ds, "lat", 192)
+        lon_var = defVar(ds, "lon", Float32, ("lon",),
+            attrib = ["units" => "degrees_east", "axis" => "X",
+                      "standard_name" => "longitude", "long_name" => "Longitude"])
+        lat_var = defVar(ds, "lat", Float32, ("lat",),
+            attrib = ["units" => "degrees_north", "axis" => "Y",
+                      "standard_name" => "latitude", "long_name" => "Latitude"])
+        lon_var[:] = Float32.(range(-180, 180, length = 384))
+        lat_var[:] = Float32.(range(-90, 90, length = 192))
+    end
+
+    @info "Preprocessing initial conditions..."
     cd(joinpath(repo_dir, "processing")) do
         run(`julia --project=$repo_dir preprocessing.jl
             --start-datetime 20100101_0000
             --end-datetime 20101001_0000
             --interval 3months
-            --data-dir $abs_output_dir`)
+            --data-dir $abs_output_dir
+            --atmos-grid-file $atmos_grid_file`)
     end
 end
 


### PR DESCRIPTION
This PR updates the wxquest_initial_conditions artifact.

Previously the atmosphere grid file was assumed to exist at a hardcoded /net/sampo path. Now we generate it programmatically from equispaced lon/lat (linspace -180:180 x384, -90:90 x192, verified against the original file on sampo),  download ERA5 at model levels, and pass the grid file explicitly to preprocessing.jl.