### PR TITLE
Rename sea-ice datafiles

### DIFF
--- a/ecco4_SIarea_SIheff_2010_01/README.md
+++ b/ecco4_SIarea_SIheff_2010_01/README.md
@@ -13,8 +13,8 @@ ECCO_WEBDAV_PASSWORD=your_ecco_webdav_password
 ```
 
 After running `create_artifacts.jl`, the subfolder `ecco4_SIarea_SIheff_2010_01_artifact` should contain the following files:
-- `ecco4_SIarea_2010_01.nc` (2.1 MB)
-- `ecco4_SIheff_2010_01.nc` (2.1 MB)
+- `SIarea_2010_01.nc` (2.1 MB)
+- `SIheff_2010_01.nc` (2.1 MB)
 
 ## Citation
 

--- a/ecco4_SIarea_SIheff_2010_01/create_artifacts.jl
+++ b/ecco4_SIarea_SIheff_2010_01/create_artifacts.jl
@@ -48,8 +48,8 @@ if isdir(artifact_dir)
 else
     mkdir(artifact_dir)
 end
-Base.cp(sic_path, joinpath(artifact_dir, "ecco4_SIarea_2010_01.nc"), force = true)
-Base.cp(sit_path, joinpath(artifact_dir, "ecco4_SIheff_2010_01.nc"), force = true)
+Base.cp(sic_path, joinpath(artifact_dir, "SIarea_2010_01.nc"), force = true)
+Base.cp(sit_path, joinpath(artifact_dir, "SIheff_2010_01.nc"), force = true)
 @info "Data files copied to $artifact_dir"
 
 # since ECCO data requires credentials, we'll make this an undownloadable artifact
@@ -73,5 +73,5 @@ open(output_artifacts, open_mode) do file
 end
 
 # ecco4_SIarea_SIheff_2010_01_artifact should now have the following files:
-# - ecco4_SIarea_2010_01.nc (2.1 MB)
-# - ecco4_SIheff_2010_01.nc (2.1 MB)
+# - SIarea_2010_01.nc (2.1 MB)
+# - SIheff_2010_01.nc (2.1 MB)


### PR DESCRIPTION
Slight adjustment to #160 to rename the datafiles (`ClimaOcean` was not expecting the `ecco4_` prefix).