### PR TITLE
Add PyCLES data for SCM EDMF CI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ artifacts.
 - [Monthly total solar irradiance from 1850 to 2299](https://github.com/CliMA/ClimaArtifacts/tree/main/cmip_monthly_tsi)
 - [Pre-computed orographic gravity wave drag tensors (h_elem=6,8,12,16)](https://github.com/CliMA/ClimaArtifacts/tree/main/ogw_computed_drag)
 - [WeatherQuest initial conditions](https://github.com/CliMA/ClimaArtifacts/tree/main/wxquest_initial_condition)
+- [PyCLES reference data](https://github.com/CliMA/ClimaArtifacts/tree/main/pycles_scm_les_data)
 
 ### Land
 - [Spun up initial conditions for soil, Jan 1, 2008, with free drainage at the bottom](https://github.com/CliMA/ClimaArtifacts/tree/main/soil_ic_2008_50m)
@@ -149,11 +150,11 @@ concentration)
    to clone the repository on a drive where you have enough storage space/quota.
    Most of the undownloadable artifacts mention the file size in their README.
 2. Navigate to the artifact of interest `cd historical_sst_sic`
-3. Instantiate the Julia project: `julia --project=. -e 'using Pkg; Pkg.instantiate()'` 
+3. Instantiate the Julia project: `julia --project=. -e 'using Pkg; Pkg.instantiate()'`
 4. In `create_artifact.jl`, comment out the line with the
    `create_artifact_guided` function (in the future, we will automate this step)
 5. Run the `create_artifact.jl` script: `julia --project=. create_artifact.jl`
-   This will automatically download and process the data. 
+   This will automatically download and process the data.
    Note also that some of the artifacts might require some set up (e.g., obtaining
    authentication tokens). These extra steps are explained in the associated README.
 > [!WARNING]

--- a/pycles_scm_les_data/Manifest.toml
+++ b/pycles_scm_les_data/Manifest.toml
@@ -1,0 +1,317 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.11.9"
+manifest_format = "2.0"
+project_hash = "74753091693fecdd4a33be59e19da0ff479810d2"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.ArtifactUtils]]
+deps = ["Downloads", "Git", "HTTP", "Pkg", "ProgressLogging", "SHA", "TOML", "gh_cli_jll"]
+git-tree-sha1 = "d111d8f4f6158a083869cb987adb957cd7330e6c"
+uuid = "8b73e784-e7d8-4ea5-973d-377fed4e3bce"
+version = "0.2.5"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BitFlags]]
+git-tree-sha1 = "bbe1079eecf9c9fbb52765193ad2bae27ae09bc8"
+uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+version = "0.1.10"
+
+[[deps.ClimaArtifactsHelper]]
+deps = ["ArtifactUtils", "Downloads", "Pkg", "REPL", "SHA"]
+path = "../ClimaArtifactsHelper.jl"
+uuid = "6ffa2572-8378-4377-82eb-ea11db28b255"
+version = "0.0.1"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.8"
+
+[[deps.ConcurrentUtilities]]
+deps = ["Serialization", "Sockets"]
+git-tree-sha1 = "21d088c496ea22914fe80906eb5bce65755e5ec8"
+uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+version = "2.5.1"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
+
+[[deps.ExceptionUnwrapping]]
+deps = ["Test"]
+git-tree-sha1 = "d36f682e590a83d63d1c7dbd287573764682d12a"
+uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
+version = "0.1.11"
+
+[[deps.Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "c307cd83373868391f3ac30b41530bc5d5d05d08"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.8.1+0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.Git]]
+deps = ["Git_LFS_jll", "Git_jll", "JLLWrappers", "OpenSSH_jll"]
+git-tree-sha1 = "824a1890086880696fc908fe12a17bcf61738bd8"
+uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
+version = "1.5.0"
+
+[[deps.Git_LFS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8c66e385d631bb934ff05e76d4a566c640c8df69"
+uuid = "020c3dae-16b3-5ae5-87b3-4cb189e250b2"
+version = "3.7.1+0"
+
+[[deps.Git_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
+git-tree-sha1 = "0dd4cfb426924210c8f42742751cbde74b27bfa3"
+uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
+version = "2.54.0+0"
+
+[[deps.HTTP]]
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "51059d23c8bb67911a2e6fd5130229113735fc7e"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "1.11.0"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.8.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.6.0+0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.7.2+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.0+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.18.0+0"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "f00544d95982ea270145636c181ceda21c4e2575"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.2.0"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
+git-tree-sha1 = "8785729fa736197687541f7053f6d8ab7fc44f92"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.1.10"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.6+0"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2023.12.12"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
+
+[[deps.OpenSSH_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+git-tree-sha1 = "57baa4b81a24c2910afbb6d853aa0685e4312bf7"
+uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
+version = "10.3.1+0"
+
+[[deps.OpenSSL]]
+deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "NetworkOptions", "OpenSSL_jll", "Sockets"]
+git-tree-sha1 = "1d1aaa7d449b58415f97d2839c318b70ffb525a0"
+uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
+version = "1.6.1"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "d8cce34295c55f47be683580f44791716045b8fe"
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.7+0"
+
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.42.0+1"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.11.0"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "5aa36f7049a63a1528fe8f7c3f2113413ffd4e1f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.1"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.ProgressLogging]]
+deps = ["Logging", "SHA", "UUIDs"]
+git-tree-sha1 = "f0803bc1171e455a04124affa9c21bba5ac4db32"
+uuid = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
+version = "0.1.6"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.SimpleBufferStream]]
+git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
+uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
+version = "1.2.0"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
+
+[[deps.URIs]]
+git-tree-sha1 = "bef26fb046d031353ef97a82e3fdb6afe7f21b1a"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.6.1"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+1"
+
+[[deps.gh_cli_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "894b4ad6ac54832386f8d01e84cab691b588f364"
+uuid = "5d31d589-30fb-542f-b82d-10325e863e38"
+version = "2.83.2+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.59.0+0"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+2"

--- a/pycles_scm_les_data/OutputArtifact.toml
+++ b/pycles_scm_les_data/OutputArtifact.toml
@@ -1,0 +1,6 @@
+[pycles_scm_les_data]
+git-tree-sha1 = "e69ae8066f1fa46324f1e3b7b81d600153f9b122"
+
+    [[pycles_scm_les_data.download]]
+    sha256 = "659547eac2ed2f94bdecea7616187926bac3561eee9250d0a96b7df2fb06d503"
+    url = "https://caltech.box.com/shared/static/bhatumhupxxmeagwm7g96nontv50g2tv.gz"

--- a/pycles_scm_les_data/Project.toml
+++ b/pycles_scm_les_data/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+ClimaArtifactsHelper = "6ffa2572-8378-4377-82eb-ea11db28b255"
+
+[sources]
+ClimaArtifactsHelper = {path = "../ClimaArtifactsHelper.jl"}

--- a/pycles_scm_les_data/README.md
+++ b/pycles_scm_les_data/README.md
@@ -1,0 +1,28 @@
+# PyCLES SCM LES reference data
+
+Single-column model (SCM) intercomparison reference data from
+[PyCLES](https://github.com/CliMA/pycles) large-eddy simulations
+(code under GNU General Public License v3.0)
+The following canonical test cases used in ClimaAtmos.jl are included:
+
+| File | Case |
+|---|---|
+| `Bomex.nc` | BOMEX shallow-cumulus |
+| `Soares.nc` | Soares dry convective boundary layer |
+| `GABLS.nc` | GABLS stable boundary layer |
+| `DYCOMS_RF01.nc` | DYCOMS RF01 stratocumulus (no drizzle) |
+| `DYCOMS_RF02.nc` | DYCOMS RF02 stratocumulus (with drizzle) |
+| `Rico.nc` | RICO trade-wind cumulus |
+| `TRMM_LBA.nc` | TRMM LBA deep convection (new-format Stats export) |
+
+## Recreating the artifact
+
+```bash
+cd /path/to/ClimaArtifacts
+julia --project=pycles_scm_les_data pycles_scm_les_data/create_artifact.jl
+```
+
+You will be prompted to upload the generated `pycles_scm_les_data_artifact.tar.gz`
+to Box (or another host) and paste the direct download URL.
+Copy the resulting `OutputArtifacts.toml` content to
+`post_processing/Artifacts.toml` in `ClimaAtmos.jl`.

--- a/pycles_scm_les_data/create_artifact.jl
+++ b/pycles_scm_les_data/create_artifact.jl
@@ -1,0 +1,56 @@
+# pycles_scm_les_data/create_artifact.jl
+#
+# Creates a Julia artifact containing the 7 PyCLES single-column LES reference
+# NetCDF files used for SCM intercomparison plots in ClimaAtmos.jl.
+#
+# Usage (from the ClimaArtifacts root):
+#   julia --project=pycles_scm_les_data pycles_scm_les_data/create_artifact.jl
+#
+# The script downloads all files from Caltech Box, bundles them into one
+# artifact directory, and calls create_artifact_guided. You will be prompted
+# to upload the generated tarball to Box (or another host), paste the direct
+# download URL, and press ENTER.  The resulting OutputArtifacts.toml entry
+# should then be copied to post_processing/Artifacts.toml in ClimaAtmos.jl.
+
+using Downloads
+using ClimaArtifactsHelper
+
+# Each entry: (canonical filename inside the artifact, Box direct-download URL)
+# Files are named to match the case_name used by edmf_scm_intercomparison.jl
+# from PR https://github.com/CliMA/ClimaAtmos.jl/pull/4610.
+# The script looks for <artifact_dir>/<case_name>.nc.
+# See PyCLES readme on how to run the model: https://github.com/CliMA/pycles/blob/master/docs/source/running.rst
+const FILES = [
+    ("Bomex.nc",       "https://caltech.box.com/shared/static/jci8l11qetlioab4cxf5myr1r492prk6.nc"),
+    ("Soares.nc",      "https://caltech.box.com/shared/static/pzuu6ii99by2s356ij69v5cb615200jq.nc"),
+    ("GABLS.nc",       "https://caltech.box.com/shared/static/zraeiftuzlgmykzhppqwrym2upqsiwyb.nc"),
+    ("DYCOMS_RF01.nc", "https://caltech.box.com/shared/static/toyvhbwmow3nz5bfa145m5fmcb2qbfuz.nc"),
+    ("DYCOMS_RF02.nc", "https://caltech.box.com/shared/static/dgie1774uw5ot8mmrmp46nauhb3ervgp.nc"),
+    ("Rico.nc",        "https://caltech.box.com/shared/static/johlutwhohvr66wn38cdo7a6rluvz708.nc"),
+    ("TRMM_LBA.nc",    "https://caltech.box.com/shared/static/67uaebore3fc00k2hh82t520u4dtuvwz.nc"),
+]
+
+const OUTPUT_DIR = "pycles_scm_les_data_artifact"
+
+if isdir(OUTPUT_DIR)
+    @warn "$OUTPUT_DIR already exists. Existing files will be skipped; delete the folder to re-download."
+else
+    mkdir(OUTPUT_DIR)
+end
+
+for (filename, url) in FILES
+    dest = joinpath(OUTPUT_DIR, filename)
+    if isfile(dest)
+        @info "$filename already present ($(round(filesize(dest)/1024^2, digits=1)) MB), skipping download"
+    else
+        @info "Downloading $filename …"
+        tmp = Downloads.download(url; progress = download_rate_callback())
+        Base.mv(tmp, dest)
+        println()  # newline after progress output
+        @info "Saved $filename ($(round(filesize(dest)/1024^2, digits=1)) MB)"
+    end
+end
+
+@info "All 7 PyCLES reference files ready in $OUTPUT_DIR"
+@info "Creating artifact (you will be prompted to upload the tarball) …"
+create_artifact_guided(OUTPUT_DIR; artifact_name = "pycles_scm_les_data")


### PR DESCRIPTION
<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

This PR adds a referemce dataset from PyCLES. The goal is to use it to compare with our single column runs in ClimaAtmos CI. 

I have never done this before. Could someone check if this looks correct?

Checklist:
- [x] I created a new folder `$artifact_name`
  - [x] I added a `README.md` in that that folder that
    - [x] describes the data and processing done to it
    - [x] lists the sources of the raw data
    - [x] lists the required citation, licenses
  - [x] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [x] I added the scripts that retrieve, process, and produce the artifact
  - [x] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [x] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [x] I uploaded the artifact folder to the Caltech cluster (in
      `/resnick/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [x] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/resnick/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [x] I added a link to the main `README.md` to point to the new artifact
