### PR TITLE
Add CalLMIP Phase 1 artifacts (evaluation data + Phase 1b met forcing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ S. Gupta et al 2022, 2024](https://github.com/CliMA/ClimaArtifacts/tree/main/soi
 - [TwoStream model implementation test data](https:////github.com/CliMA/ClimaArtifacts/tree/main/twostr_test)
 - [Berkeley Earth Global Gridded Temperature Data](https:////github.com/CliMA/ClimaArtifacts/tree/main/surface_temperatures)
 - [Selected FLUXNET tower data](https:////github.com/CliMA/ClimaArtifacts/tree/main/fluxnet_sites)
+- [CalLMIP Phase 1 evaluation data (flux observations + CO2 forcing)](https://github.com/CliMA/ClimaArtifacts/tree/main/callmip_phase1)
+- [CalLMIP Phase 1b meteorological forcing (21 sites; FLUXNET2015 / PLUMBER2)](https://github.com/CliMA/ClimaArtifacts/tree/main/callmip_phase1_forcing)
 - [ESM-SnowMIP data](https://github.com/CliMA/ClimaArtifacts/tree/main/snowmip)
 - [ERA5 Monthly Averages 2008](https:////github.com/CliMA/ClimaArtifacts/tree/main/era5_surface_fluxes_2008)
 - [Earth bedrock depth at 30 and 60 arc-second resolutions](https:////github.com/CliMA/ClimaArtifacts/tree/main/bedrock_depth)

--- a/callmip_phase1/Manifest.toml
+++ b/callmip_phase1/Manifest.toml
@@ -1,0 +1,327 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.5"
+manifest_format = "2.0"
+project_hash = "34e044739fb8bb26cff83f4598fa924bcae404a5"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.ArtifactUtils]]
+deps = ["Downloads", "Git", "HTTP", "Pkg", "ProgressLogging", "SHA", "TOML", "gh_cli_jll"]
+git-tree-sha1 = "d111d8f4f6158a083869cb987adb957cd7330e6c"
+uuid = "8b73e784-e7d8-4ea5-973d-377fed4e3bce"
+version = "0.2.5"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BitFlags]]
+git-tree-sha1 = "bbe1079eecf9c9fbb52765193ad2bae27ae09bc8"
+uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+version = "0.1.10"
+
+[[deps.ClimaArtifactsHelper]]
+deps = ["ArtifactUtils", "Downloads", "Pkg", "REPL", "SHA"]
+path = "../ClimaArtifactsHelper.jl"
+uuid = "6ffa2572-8378-4377-82eb-ea11db28b255"
+version = "0.0.1"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.8"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.ConcurrentUtilities]]
+deps = ["Serialization", "Sockets"]
+git-tree-sha1 = "21d088c496ea22914fe80906eb5bce65755e5ec8"
+uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+version = "2.5.1"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.7.0"
+
+[[deps.ExceptionUnwrapping]]
+deps = ["Test"]
+git-tree-sha1 = "d36f682e590a83d63d1c7dbd287573764682d12a"
+uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
+version = "0.1.11"
+
+[[deps.Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "c307cd83373868391f3ac30b41530bc5d5d05d08"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.8.1+0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.Git]]
+deps = ["Git_LFS_jll", "Git_jll", "JLLWrappers", "OpenSSH_jll"]
+git-tree-sha1 = "824a1890086880696fc908fe12a17bcf61738bd8"
+uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
+version = "1.5.0"
+
+[[deps.Git_LFS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8c66e385d631bb934ff05e76d4a566c640c8df69"
+uuid = "020c3dae-16b3-5ae5-87b3-4cb189e250b2"
+version = "3.7.1+0"
+
+[[deps.Git_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
+git-tree-sha1 = "0dd4cfb426924210c8f42742751cbde74b27bfa3"
+uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
+version = "2.54.0+0"
+
+[[deps.HTTP]]
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "51059d23c8bb67911a2e6fd5130229113735fc7e"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "1.11.0"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.8.0"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.15.0+0"
+
+[[deps.LibGit2]]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.0+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.3+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.18.0+0"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "f00544d95982ea270145636c181ceda21c4e2575"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.2.0"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
+git-tree-sha1 = "8785729fa736197687541f7053f6d8ab7fc44f92"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.1.10"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "ff69a2b1330bcb730b9ac1ab7dd680176f5896b8"
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.1010+0"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2025.11.4"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+[[deps.OpenSSH_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+git-tree-sha1 = "57baa4b81a24c2910afbb6d853aa0685e4312bf7"
+uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
+version = "10.3.1+0"
+
+[[deps.OpenSSL]]
+deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "NetworkOptions", "OpenSSL_jll", "Sockets"]
+git-tree-sha1 = "1d1aaa7d449b58415f97d2839c318b70ffb525a0"
+uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
+version = "1.6.1"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
+
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.44.0+1"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.12.1"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.ProgressLogging]]
+deps = ["Logging", "SHA", "UUIDs"]
+git-tree-sha1 = "f0803bc1171e455a04124affa9c21bba5ac4db32"
+uuid = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
+version = "0.1.6"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.SimpleBufferStream]]
+git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
+uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
+version = "1.2.0"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
+
+[[deps.URIs]]
+git-tree-sha1 = "bef26fb046d031353ef97a82e3fdb6afe7f21b1a"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.6.1"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.3.1+2"
+
+[[deps.gh_cli_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "894b4ad6ac54832386f8d01e84cab691b588f364"
+uuid = "5d31d589-30fb-542f-b82d-10325e863e38"
+version = "2.83.2+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.64.0+1"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.7.0+0"

--- a/callmip_phase1/OutputArtifacts.toml
+++ b/callmip_phase1/OutputArtifacts.toml
@@ -1,7 +1,4 @@
-# CalLMIP Phase 1 evaluation data (flux observations + CO2 forcing) from the
-# callmip-org/Phase1 GitHub repository (MIT). Copy this entry into the consuming
-# package's Artifacts.toml. The [[...download]] section (sha256 + url) is added after
-# the tarball is uploaded to the Caltech Data Archive / Box; for cluster-only use, bind
-# this git-tree-sha1 to the cluster path via Overrides.toml.
+# CalLMIP Phase 1 evaluation data (flux observations + CO2 forcing).
+# Copy this entry into the consuming package's Artifacts.toml.
 [callmip_phase1]
 git-tree-sha1 = "c8014d3bbd838fcaa01bd2a69523b3fa98f28c5c"

--- a/callmip_phase1/OutputArtifacts.toml
+++ b/callmip_phase1/OutputArtifacts.toml
@@ -1,0 +1,7 @@
+# CalLMIP Phase 1 evaluation data (flux observations + CO2 forcing) from the
+# callmip-org/Phase1 GitHub repository (MIT). Copy this entry into the consuming
+# package's Artifacts.toml. The [[...download]] section (sha256 + url) is added after
+# the tarball is uploaded to the Caltech Data Archive / Box; for cluster-only use, bind
+# this git-tree-sha1 to the cluster path via Overrides.toml.
+[callmip_phase1]
+git-tree-sha1 = "c8014d3bbd838fcaa01bd2a69523b3fa98f28c5c"

--- a/callmip_phase1/OutputArtifacts.toml
+++ b/callmip_phase1/OutputArtifacts.toml
@@ -1,4 +1,2 @@
-# CalLMIP Phase 1 evaluation data (flux observations + CO2 forcing).
-# Copy this entry into the consuming package's Artifacts.toml.
 [callmip_phase1]
 git-tree-sha1 = "c8014d3bbd838fcaa01bd2a69523b3fa98f28c5c"

--- a/callmip_phase1/Project.toml
+++ b/callmip_phase1/Project.toml
@@ -1,0 +1,3 @@
+[deps]
+ClimaArtifactsHelper = "6ffa2572-8378-4377-82eb-ea11db28b255"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"

--- a/callmip_phase1/README.md
+++ b/callmip_phase1/README.md
@@ -14,39 +14,36 @@ The artifact mirrors the `Data/` tree of the CalLMIP Phase 1 repository:
 | `Data/Phase1b/*.nc` | Daily-aggregated flux observation files for the **21 Phase 1b sites** (same variable set). |
 | `Data/Non-site-specific_forcing/CO2_1700_2024_TRENDYv2025.txt` | Atmospheric CO2 forcing (TRENDY v2025) for the site runs. |
 
-## What is NOT included: the meteorological forcing
+## Meteorological forcing (companion artifact)
 
-The per-site **meteorological forcing** (e.g. `*_Met.nc`, which also carries LAI) is **not**
-in the CalLMIP GitHub repository. Per the CalLMIP Phase 1 protocol (v2), the gap-filled
-in-situ met forcing is downloaded from **modelevaluation.org (ME-org)**, the CalLMIP
-workspace (requires an ME-org account). It derives from the **PLUMBER2 dataset**
-(Abramowitz et al., 2024), which provides pre-selected **FLUXNET2015 (CC-BY-4.0)** sites.
-
-Because ME-org requires authentication, the met forcing cannot be auto-downloaded here.
-The forcing is CC-BY-4.0, so it may be redistributed (with citation): a companion artifact
-that bundles the ME-org/PLUMBER2 met-forcing files (placed manually at build time) can be
-created so a consuming package has both forcing and observations. See the consuming
-package's docs for which path it expects.
+This artifact holds the flux **observations** and the **atmospheric CO₂ forcing** (listed
+above). The per-site **meteorological forcing** (`*_Met.nc`, the atmospheric drivers + LAI) is
+*not* part of the CalLMIP repository and is **not** included here — it is provided separately in
+the companion [`callmip_phase1_forcing`](../callmip_phase1_forcing) artifact. Together the two
+give a consuming package the observations + CO₂ forcing (here) and the meteorological drivers
+(there).
 
 ## Source and citation
 
 - Repository: https://github.com/callmip-org/Phase1 (MIT license)
-- Project: CalLMIP — https://callmip-org.github.io
-- The flux observations derive from FLUXNET2015; please also follow the FLUXNET2015 /
-  ICOS data-use policy and cite the contributing sites.
+- Project: **CalLMIP** (Calibration of Land Models Intercomparison Project),
+  https://callmip-org.github.io
+- Flux observations derive from **FLUXNET2015**: Pastorello, G., et al. (2020). The FLUXNET2015
+  dataset and the ONEFlux processing pipeline for eddy covariance data. *Scientific Data* 7, 225.
+  https://doi.org/10.1038/s41597-020-0534-3
 
-When using this artifact, cite the CalLMIP project and the underlying FLUXNET2015 data.
+When using this artifact, cite the **CalLMIP project** (https://callmip-org.github.io) and the
+underlying **FLUXNET2015** data, and follow the FLUXNET2015 / ICOS data-use policy.
 
 ## Recreating the artifact
 
-```
+```bash
 cd callmip_phase1
 julia --project create_artifact.jl
 ```
 
-The script downloads the CalLMIP Phase 1 repository tarball, extracts its `Data/` tree,
-and runs the guided artifact-creation flow. You will be asked to upload the produced
-`callmip_phase1_artifact.tar.gz` to the Caltech Data Archive / Box and paste its direct
-link; the resulting `OutputArtifacts.toml` entry is then copied into the consuming
-package's `Artifacts.toml`. Pin `COMMIT` in `create_artifact.jl` to a specific CalLMIP
-commit SHA for full reproducibility.
+The script downloads the pinned CalLMIP Phase 1 commit (`COMMIT` in `create_artifact.jl`,
+which reproduces the `git-tree-sha1` in `OutputArtifacts.toml`), extracts its `Data/` tree, and
+runs the guided artifact-creation flow. You will be asked to upload the produced
+`callmip_phase1_artifact.tar.gz` and paste its direct link; the resulting `OutputArtifacts.toml`
+entry is then copied into the consuming package's `Artifacts.toml`.

--- a/callmip_phase1/README.md
+++ b/callmip_phase1/README.md
@@ -1,0 +1,52 @@
+# CalLMIP Phase 1 data
+
+Evaluation data for **CalLMIP** (Calibration of Land Models Intercomparison Project)
+**Phase 1**, packaged from the official repository
+[`callmip-org/Phase1`](https://github.com/callmip-org/Phase1) (MIT license).
+
+## Contents
+
+The artifact mirrors the `Data/` tree of the CalLMIP Phase 1 repository:
+
+| Path | Description |
+|------|-------------|
+| `Data/Phase1a-test/DK-Sor_daily_aggregated_1997-2013_FLUXNET2015_Flux.nc` | Flux observations for the **DK-Sor** (Sorø, Denmark) single-site **Phase 1a** test calibration: NEE, Qle, Qh and their uncertainties. Site metadata (PFT, % cover, soil-layer depths, soil texture) are in the global attributes. |
+| `Data/Phase1b/*.nc` | Daily-aggregated flux observation files for the **21 Phase 1b sites** (same variable set). |
+| `Data/Non-site-specific_forcing/CO2_1700_2024_TRENDYv2025.txt` | Atmospheric CO2 forcing (TRENDY v2025) for the site runs. |
+
+## What is NOT included: the meteorological forcing
+
+The per-site **meteorological forcing** (e.g. `*_Met.nc`, which also carries LAI) is **not**
+in the CalLMIP GitHub repository. Per the CalLMIP Phase 1 protocol (v2), the gap-filled
+in-situ met forcing is downloaded from **modelevaluation.org (ME-org)**, the CalLMIP
+workspace (requires an ME-org account). It derives from the **PLUMBER2 dataset**
+(Abramowitz et al., 2024), which provides pre-selected **FLUXNET2015 (CC-BY-4.0)** sites.
+
+Because ME-org requires authentication, the met forcing cannot be auto-downloaded here.
+The forcing is CC-BY-4.0, so it may be redistributed (with citation): a companion artifact
+that bundles the ME-org/PLUMBER2 met-forcing files (placed manually at build time) can be
+created so a consuming package has both forcing and observations. See the consuming
+package's docs for which path it expects.
+
+## Source and citation
+
+- Repository: https://github.com/callmip-org/Phase1 (MIT license)
+- Project: CalLMIP — https://callmip-org.github.io
+- The flux observations derive from FLUXNET2015; please also follow the FLUXNET2015 /
+  ICOS data-use policy and cite the contributing sites.
+
+When using this artifact, cite the CalLMIP project and the underlying FLUXNET2015 data.
+
+## Recreating the artifact
+
+```
+cd callmip_phase1
+julia --project create_artifact.jl
+```
+
+The script downloads the CalLMIP Phase 1 repository tarball, extracts its `Data/` tree,
+and runs the guided artifact-creation flow. You will be asked to upload the produced
+`callmip_phase1_artifact.tar.gz` to the Caltech Data Archive / Box and paste its direct
+link; the resulting `OutputArtifacts.toml` entry is then copied into the consuming
+package's `Artifacts.toml`. Pin `COMMIT` in `create_artifact.jl` to a specific CalLMIP
+commit SHA for full reproducibility.

--- a/callmip_phase1/create_artifact.jl
+++ b/callmip_phase1/create_artifact.jl
@@ -1,0 +1,45 @@
+# Creates the `callmip_phase1` artifact from the CalLMIP Phase 1 repository
+# (https://github.com/callmip-org/Phase1, MIT license).
+#
+# The artifact packages the CalLMIP Phase 1 `Data/` tree:
+#   - Phase1a-test/  : the DK-Sor single-site test-calibration flux file
+#                      (DK-Sor_daily_aggregated_1997-2013_FLUXNET2015_Flux.nc; NEE, Qle, Qh
+#                       + uncertainties; site metadata in global attributes)
+#   - Phase1b/       : daily-aggregated flux observation files for the 21 Phase 1b sites
+#   - Non-site-specific_forcing/ : atmospheric CO2 forcing (TRENDY v2025)
+#
+# NOTE: the per-site *meteorological forcing* is NOT part of the CalLMIP repository
+# (it is the upstream FLUXNET2015 data, obtained separately), so it is not included here.
+#
+# To recreate: `julia --project create_artifact.jl` (interactive: you will be asked to
+# upload the produced tarball and paste its download link).
+
+using Downloads
+using ClimaArtifactsHelper
+
+# Pin to a specific commit for reproducibility (update as needed).
+const COMMIT = "main"
+const REPO_TARBALL = "https://github.com/callmip-org/Phase1/archive/$(COMMIT).tar.gz"
+
+output_dir = "callmip_phase1_artifact"
+if isdir(output_dir)
+    @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
+    @warn "Abort this calculation, unless you know what you are doing."
+else
+    mkdir(output_dir)
+end
+
+# Download + extract the CalLMIP Phase 1 repository tarball, then keep only Data/.
+@info "Downloading CalLMIP Phase 1 repository tarball ($COMMIT)"
+tgz = Downloads.download(REPO_TARBALL)
+extract_dir = mktempdir()
+run(`tar -xzf $tgz -C $extract_dir`)
+# GitHub tarballs extract to a single top-level folder `Phase1-<commit>`.
+repo_root = only(filter(isdir, readdir(extract_dir; join = true)))
+data_src = joinpath(repo_root, "Data")
+isdir(data_src) || error("Data/ not found in the CalLMIP tarball at $repo_root")
+
+cp(data_src, joinpath(output_dir, "Data"); force = true)
+@info "CalLMIP Phase 1 Data/ assembled into $output_dir"
+
+create_artifact_guided(output_dir; artifact_name = basename(@__DIR__))

--- a/callmip_phase1/create_artifact.jl
+++ b/callmip_phase1/create_artifact.jl
@@ -17,8 +17,10 @@
 using Downloads
 using ClimaArtifactsHelper
 
-# Pin to a specific commit for reproducibility (update as needed).
-const COMMIT = "main"
+# Pinned to a specific callmip-org/Phase1 commit for reproducibility: building from this
+# commit reproduces the git-tree-sha1 in OutputArtifacts.toml
+# (c8014d3bbd838fcaa01bd2a69523b3fa98f28c5c). Bump this SHA to repackage a newer release.
+const COMMIT = "4101e36679de42789fbd600f4ee69d0cf16b78fc"
 const REPO_TARBALL = "https://github.com/callmip-org/Phase1/archive/$(COMMIT).tar.gz"
 
 output_dir = "callmip_phase1_artifact"

--- a/callmip_phase1_forcing/Manifest.toml
+++ b/callmip_phase1_forcing/Manifest.toml
@@ -1,0 +1,327 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.5"
+manifest_format = "2.0"
+project_hash = "e12274832541e5ee28b988bad9e6c10379fb71cb"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.2"
+
+[[deps.ArtifactUtils]]
+deps = ["Downloads", "Git", "HTTP", "Pkg", "ProgressLogging", "SHA", "TOML", "gh_cli_jll"]
+git-tree-sha1 = "d111d8f4f6158a083869cb987adb957cd7330e6c"
+uuid = "8b73e784-e7d8-4ea5-973d-377fed4e3bce"
+version = "0.2.5"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+version = "1.11.0"
+
+[[deps.BitFlags]]
+git-tree-sha1 = "bbe1079eecf9c9fbb52765193ad2bae27ae09bc8"
+uuid = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+version = "0.1.10"
+
+[[deps.ClimaArtifactsHelper]]
+deps = ["ArtifactUtils", "Downloads", "Pkg", "REPL", "SHA"]
+path = "../ClimaArtifactsHelper.jl"
+uuid = "6ffa2572-8378-4377-82eb-ea11db28b255"
+version = "0.0.1"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "962834c22b66e32aa10f7611c08c8ca4e20749a9"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.8"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.ConcurrentUtilities]]
+deps = ["Serialization", "Sockets"]
+git-tree-sha1 = "21d088c496ea22914fe80906eb5bce65755e5ec8"
+uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
+version = "2.5.1"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.7.0"
+
+[[deps.ExceptionUnwrapping]]
+deps = ["Test"]
+git-tree-sha1 = "d36f682e590a83d63d1c7dbd287573764682d12a"
+uuid = "460bff9d-24e4-43bc-9d9f-a8973cb893f4"
+version = "0.1.11"
+
+[[deps.Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "c307cd83373868391f3ac30b41530bc5d5d05d08"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.8.1+0"
+
+[[deps.FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+version = "1.11.0"
+
+[[deps.Git]]
+deps = ["Git_LFS_jll", "Git_jll", "JLLWrappers", "OpenSSH_jll"]
+git-tree-sha1 = "824a1890086880696fc908fe12a17bcf61738bd8"
+uuid = "d7ba0133-e1db-5d97-8f8c-041e4b3a1eb2"
+version = "1.5.0"
+
+[[deps.Git_LFS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "8c66e385d631bb934ff05e76d4a566c640c8df69"
+uuid = "020c3dae-16b3-5ae5-87b3-4cb189e250b2"
+version = "3.7.1+0"
+
+[[deps.Git_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "LibCURL_jll", "Libdl", "Libiconv_jll", "OpenSSL_jll", "PCRE2_jll", "Zlib_jll"]
+git-tree-sha1 = "0dd4cfb426924210c8f42742751cbde74b27bfa3"
+uuid = "f8c6e375-362e-5223-8a59-34ff63f689eb"
+version = "2.54.0+0"
+
+[[deps.HTTP]]
+deps = ["Base64", "CodecZlib", "ConcurrentUtilities", "Dates", "ExceptionUnwrapping", "Logging", "LoggingExtras", "MbedTLS", "NetworkOptions", "OpenSSL", "PrecompileTools", "Random", "SimpleBufferStream", "Sockets", "URIs", "UUIDs"]
+git-tree-sha1 = "51059d23c8bb67911a2e6fd5130229113735fc7e"
+uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
+version = "1.11.0"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+version = "1.11.0"
+
+[[deps.JLLWrappers]]
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7204148362dafe5fe6a273f855b8ccbe4df8173e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.8.0"
+
+[[deps.JuliaSyntaxHighlighting]]
+deps = ["StyledStrings"]
+uuid = "ac6e5ff7-fb65-4e79-a425-ec3bc9c03011"
+version = "1.12.0"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.4"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "8.15.0+0"
+
+[[deps.LibGit2]]
+deps = ["LibGit2_jll", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+version = "1.11.0"
+
+[[deps.LibGit2_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "OpenSSL_jll"]
+uuid = "e37daf67-58a4-590a-8e99-b0245dd2ffc5"
+version = "1.9.0+0"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "OpenSSL_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.11.3+1"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "be484f5c92fad0bd8acfef35fe017900b0b73809"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.18.0+0"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+version = "1.11.0"
+
+[[deps.LoggingExtras]]
+deps = ["Dates", "Logging"]
+git-tree-sha1 = "f00544d95982ea270145636c181ceda21c4e2575"
+uuid = "e6f89c97-d47a-5376-807f-9c37f3926c36"
+version = "1.2.0"
+
+[[deps.Markdown]]
+deps = ["Base64", "JuliaSyntaxHighlighting", "StyledStrings"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+version = "1.11.0"
+
+[[deps.MbedTLS]]
+deps = ["Dates", "MbedTLS_jll", "MozillaCACerts_jll", "NetworkOptions", "Random", "Sockets"]
+git-tree-sha1 = "8785729fa736197687541f7053f6d8ab7fc44f92"
+uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
+version = "1.1.10"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "ff69a2b1330bcb730b9ac1ab7dd680176f5896b8"
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.1010+0"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2025.11.4"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.3.0"
+
+[[deps.OpenSSH_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "OpenSSL_jll", "Zlib_jll"]
+git-tree-sha1 = "57baa4b81a24c2910afbb6d853aa0685e4312bf7"
+uuid = "9bd350c2-7e96-507f-8002-3f2e150b4e1b"
+version = "10.3.1+0"
+
+[[deps.OpenSSL]]
+deps = ["BitFlags", "Dates", "MozillaCACerts_jll", "NetworkOptions", "OpenSSL_jll", "Sockets"]
+git-tree-sha1 = "1d1aaa7d449b58415f97d2839c318b70ffb525a0"
+uuid = "4d8831e6-92b7-49fb-bdf8-b643e874388c"
+version = "1.6.1"
+
+[[deps.OpenSSL_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+version = "3.5.4+0"
+
+[[deps.PCRE2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
+version = "10.44.0+1"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "Random", "SHA", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.12.1"
+weakdeps = ["REPL"]
+
+    [deps.Pkg.extensions]
+    REPLExt = "REPL"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.ProgressLogging]]
+deps = ["Logging", "SHA", "UUIDs"]
+git-tree-sha1 = "f0803bc1171e455a04124affa9c21bba5ac4db32"
+uuid = "33c8b6b6-d38a-422a-b730-caa89a2f386c"
+version = "0.1.6"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "JuliaSyntaxHighlighting", "Markdown", "Sockets", "StyledStrings", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.SimpleBufferStream]]
+git-tree-sha1 = "f305871d2f381d21527c770d4788c06c097c9bc1"
+uuid = "777ac1f9-54b0-4bf8-805c-2214025038e7"
+version = "1.2.0"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+version = "1.11.0"
+
+[[deps.StyledStrings]]
+uuid = "f489334b-da3d-4c2e-b8f0-e476e12c162b"
+version = "1.11.0"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+version = "1.11.0"
+
+[[deps.TranscodingStreams]]
+git-tree-sha1 = "0c45878dcfdcfa8480052b6ab162cdd138781742"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.11.3"
+
+[[deps.URIs]]
+git-tree-sha1 = "bef26fb046d031353ef97a82e3fdb6afe7f21b1a"
+uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
+version = "1.6.1"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+version = "1.11.0"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.3.1+2"
+
+[[deps.gh_cli_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl"]
+git-tree-sha1 = "894b4ad6ac54832386f8d01e84cab691b588f364"
+uuid = "5d31d589-30fb-542f-b82d-10325e863e38"
+version = "2.83.2+0"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.64.0+1"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.7.0+0"

--- a/callmip_phase1_forcing/OutputArtifacts.toml
+++ b/callmip_phase1_forcing/OutputArtifacts.toml
@@ -1,4 +1,2 @@
-# CalLMIP Phase 1b meteorological forcing (21 *_Met.nc; PLUMBER2 / FLUXNET2015, CC-BY-4.0).
-# Copy this entry into the consuming package's Artifacts.toml.
 [callmip_phase1_forcing]
 git-tree-sha1 = "a0c004071c73d047095a01faedf017571e5237ef"

--- a/callmip_phase1_forcing/OutputArtifacts.toml
+++ b/callmip_phase1_forcing/OutputArtifacts.toml
@@ -1,0 +1,6 @@
+# CalLMIP Phase 1b meteorological forcing (21 *_Met.nc; PLUMBER2 / FLUXNET2015, CC-BY-4.0)
+# obtained from modelevaluation.org. Copy this entry into the consuming package's
+# Artifacts.toml. Add the [[...download]] section after uploading the tarball, or bind
+# this git-tree-sha1 to the cluster path via Overrides.toml.
+[callmip_phase1_forcing]
+git-tree-sha1 = "a0c004071c73d047095a01faedf017571e5237ef"

--- a/callmip_phase1_forcing/OutputArtifacts.toml
+++ b/callmip_phase1_forcing/OutputArtifacts.toml
@@ -1,6 +1,4 @@
-# CalLMIP Phase 1b meteorological forcing (21 *_Met.nc; PLUMBER2 / FLUXNET2015, CC-BY-4.0)
-# obtained from modelevaluation.org. Copy this entry into the consuming package's
-# Artifacts.toml. Add the [[...download]] section after uploading the tarball, or bind
-# this git-tree-sha1 to the cluster path via Overrides.toml.
+# CalLMIP Phase 1b meteorological forcing (21 *_Met.nc; PLUMBER2 / FLUXNET2015, CC-BY-4.0).
+# Copy this entry into the consuming package's Artifacts.toml.
 [callmip_phase1_forcing]
 git-tree-sha1 = "a0c004071c73d047095a01faedf017571e5237ef"

--- a/callmip_phase1_forcing/Project.toml
+++ b/callmip_phase1_forcing/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+ClimaArtifactsHelper = "6ffa2572-8378-4377-82eb-ea11db28b255"

--- a/callmip_phase1_forcing/README.md
+++ b/callmip_phase1_forcing/README.md
@@ -1,0 +1,46 @@
+# CalLMIP Phase 1b meteorological forcing
+
+Gap-filled in-situ **meteorological forcing** (atmospheric drivers + LAI) for the 21
+**CalLMIP Phase 1b** calibration sites, as used by the CalLMIP Phase 1 experiments.
+
+This is the **forcing/driver** companion to the [`callmip_phase1`](../callmip_phase1)
+artifact, which provides the matching flux **observations** and CO2 forcing from the
+CalLMIP GitHub repository.
+
+## Contents
+
+21 NetCDF files, one per site, named `<SITE>_<YEARS>_FLUXNET2015_Met.nc`, e.g.:
+
+```
+DK-Sor_1997-2014_FLUXNET2015_Met.nc   FI-Hyy_1996-2014_FLUXNET2015_Met.nc
+CH-Dav_1997-2014_FLUXNET2015_Met.nc   DE-Hai_2000-2012_FLUXNET2015_Met.nc
+... (21 sites total: CA-Qfo, CH-Dav, DE-Gri, DE-Hai, DE-Tha, DK-Sor, FI-Hyy,
+FR-Pue, IT-Lav, IT-MBo, IT-Noe, NL-Loo, RU-Fyo, US-MMS, US-NR1, US-SRG, US-SRM,
+US-Ton, US-Var, US-Whs, US-Wkg)
+```
+
+Each file carries the sub-daily meteorological drivers (and LAI) for the site.
+
+## Source, provenance, license
+
+Downloaded from the CalLMIP workspace on **modelevaluation.org (ME-org)** per the CalLMIP
+Phase 1 protocol (v2). The data derive from the **PLUMBER2 dataset**
+(Abramowitz et al., 2024, ESSD, https://doi.org/10.5194/essd-16-1389-2024), which provides
+pre-selected **FLUXNET2015 (CC-BY-4.0)** sites. When using this artifact, cite PLUMBER2 and
+FLUXNET2015 and follow the FLUXNET2015 data-use policy.
+
+## Recreating the artifact
+
+ME-org requires authentication, so the files cannot be auto-downloaded. Obtain the
+Phase 1b met forcing from ME-org (the `Phase-1b-Calibration-DS.zip` download), then:
+
+```
+CALLMIP_MET_SRC=/path/to/Phase-1b-Calibration-DS.zip julia --project create_artifact.jl
+```
+
+(Alternatively point `CALLMIP_MET_SRC` at a directory containing the `*_Met.nc` files.)
+The artifact is ~0.4 GB; `create_artifact_guided` will archive it and ask for the upload
+link (Caltech Data Archive / Box) to produce the `OutputArtifacts.toml` entry. For
+cluster-only use, instead upload the folder to
+`/groups/esm/ClimaArtifacts/artifacts/callmip_phase1_forcing` and bind its hash via the
+shared `Overrides.toml`.

--- a/callmip_phase1_forcing/README.md
+++ b/callmip_phase1_forcing/README.md
@@ -9,38 +9,42 @@ CalLMIP GitHub repository.
 
 ## Contents
 
-21 NetCDF files, one per site, named `<SITE>_<YEARS>_FLUXNET2015_Met.nc`, e.g.:
+21 NetCDF files, one per site, named `<SITE>_<YEARS>_FLUXNET2015_Met.nc`. Each file carries the
+sub-daily meteorological drivers (and LAI) for one site.
+
+**The year coverage differs by site** — it is encoded in each filename. For example:
 
 ```
-DK-Sor_1997-2014_FLUXNET2015_Met.nc   FI-Hyy_1996-2014_FLUXNET2015_Met.nc
-CH-Dav_1997-2014_FLUXNET2015_Met.nc   DE-Hai_2000-2012_FLUXNET2015_Met.nc
-... (21 sites total: CA-Qfo, CH-Dav, DE-Gri, DE-Hai, DE-Tha, DK-Sor, FI-Hyy,
-FR-Pue, IT-Lav, IT-MBo, IT-Noe, NL-Loo, RU-Fyo, US-MMS, US-NR1, US-SRG, US-SRM,
-US-Ton, US-Var, US-Whs, US-Wkg)
+DK-Sor_1997-2014_FLUXNET2015_Met.nc   (1997–2014)
+FI-Hyy_1996-2014_FLUXNET2015_Met.nc   (1996–2014)
+DE-Hai_2000-2012_FLUXNET2015_Met.nc   (2000–2012)
 ```
 
-Each file carries the sub-daily meteorological drivers (and LAI) for the site.
+The 21 sites are: CA-Qfo, CH-Dav, DE-Gri, DE-Hai, DE-Tha, DK-Sor, FI-Hyy, FR-Pue, IT-Lav,
+IT-MBo, IT-Noe, NL-Loo, RU-Fyo, US-MMS, US-NR1, US-SRG, US-SRM, US-Ton, US-Var, US-Whs, US-Wkg.
 
 ## Source, provenance, license
 
-Downloaded from the CalLMIP workspace on **modelevaluation.org (ME-org)** per the CalLMIP
-Phase 1 protocol (v2). The data derive from the **PLUMBER2 dataset**
-(Abramowitz et al., 2024, ESSD, https://doi.org/10.5194/essd-16-1389-2024), which provides
-pre-selected **FLUXNET2015 (CC-BY-4.0)** sites. When using this artifact, cite PLUMBER2 and
-FLUXNET2015 and follow the FLUXNET2015 data-use policy.
+Downloaded from the CalLMIP workspace on **modelevaluation.org (ME-org)**,
+https://modelevaluation.org/, per the CalLMIP Phase 1 protocol (v2). The data derive from the
+**PLUMBER2 dataset** (Abramowitz et al., 2024, ESSD, https://doi.org/10.5194/essd-16-1389-2024),
+which provides pre-selected **FLUXNET2015 (CC-BY-4.0)** sites: Pastorello, G., et al. (2020). The
+FLUXNET2015 dataset and the ONEFlux processing pipeline for eddy covariance data. *Scientific
+Data* 7, 225. https://doi.org/10.1038/s41597-020-0534-3
+
+When using this artifact, cite **PLUMBER2** and **FLUXNET2015** and follow the FLUXNET2015
+data-use policy.
 
 ## Recreating the artifact
 
-ME-org requires authentication, so the files cannot be auto-downloaded. Obtain the
-Phase 1b met forcing from ME-org (the `Phase-1b-Calibration-DS.zip` download), then:
+ME-org (https://modelevaluation.org/) requires authentication, so the files cannot be
+auto-downloaded. Obtain the Phase 1b met forcing from the CalLMIP workspace on ME-org (the
+`Phase-1b-Calibration-DS.zip` download), then:
 
-```
+```bash
 CALLMIP_MET_SRC=/path/to/Phase-1b-Calibration-DS.zip julia --project create_artifact.jl
 ```
 
 (Alternatively point `CALLMIP_MET_SRC` at a directory containing the `*_Met.nc` files.)
-The artifact is ~0.4 GB; `create_artifact_guided` will archive it and ask for the upload
-link (Caltech Data Archive / Box) to produce the `OutputArtifacts.toml` entry. For
-cluster-only use, instead upload the folder to
-`/groups/esm/ClimaArtifacts/artifacts/callmip_phase1_forcing` and bind its hash via the
-shared `Overrides.toml`.
+The artifact is ~0.4 GB; `create_artifact_guided` will archive it and ask for the upload link to
+produce the `OutputArtifacts.toml` entry.

--- a/callmip_phase1_forcing/create_artifact.jl
+++ b/callmip_phase1_forcing/create_artifact.jl
@@ -1,0 +1,44 @@
+# Creates the `callmip_phase1_forcing` artifact: gap-filled in-situ meteorological
+# forcing (drivers + LAI) for the 21 CalLMIP Phase 1b calibration sites.
+#
+# Provenance: per the CalLMIP Phase 1 protocol (v2), the met forcing is downloaded from
+# the CalLMIP workspace on modelevaluation.org (ME-org; requires an account). The data
+# derive from the PLUMBER2 dataset (Abramowitz et al., 2024), pre-selected FLUXNET2015
+# (CC-BY-4.0) sites.
+#
+# Because ME-org requires authentication, the files cannot be fetched automatically here.
+# Obtain the Phase 1b forcing from ME-org and point CALLMIP_MET_SRC at either the
+# directory of `*_Met.nc` files or the ME-org `Phase-1b-Calibration-DS.zip`:
+#
+#   CALLMIP_MET_SRC=/path/to/Phase-1b-Calibration-DS.zip julia --project create_artifact.jl
+#
+using ClimaArtifactsHelper
+
+src = get(ENV, "CALLMIP_MET_SRC", "")
+isempty(src) && error(
+    "Set CALLMIP_MET_SRC to the directory of *_Met.nc files or the ME-org " *
+    "Phase-1b-Calibration-DS.zip (obtained from modelevaluation.org).",
+)
+
+output_dir = "callmip_phase1_forcing_artifact"
+if isdir(output_dir)
+    @warn "$output_dir already exists. Content will end up in the artifact and may be overwritten."
+else
+    mkdir(output_dir)
+end
+
+if endswith(src, ".zip")
+    @info "Extracting *_Met.nc from $src"
+    run(`unzip -o -j $src "*_Met.nc" -d $output_dir`)
+else
+    @info "Copying *_Met.nc from $src"
+    for f in readdir(src; join = true)
+        endswith(f, "_Met.nc") && cp(f, joinpath(output_dir, basename(f)); force = true)
+    end
+end
+
+n = count(f -> endswith(f, "_Met.nc"), readdir(output_dir))
+n == 21 || @warn "Expected 21 *_Met.nc files for Phase 1b, found $n"
+@info "Assembled $n met-forcing files into $output_dir"
+
+create_artifact_guided(output_dir; artifact_name = basename(@__DIR__))


### PR DESCRIPTION
callmip_phase1: CalLMIP Phase 1 flux observations + CO2 forcing from the callmip-org/Phase1 repository (MIT).
callmip_phase1_forcing: gap-filled meteorological forcing for the 21 CalLMIP Phase 1b sites (PLUMBER2 / FLUXNET2015, CC-BY-4.0; from modelevaluation.org).

Each folder has a README, Project.toml, create_artifact.jl, and OutputArtifacts.toml with the computed git-tree-sha1. the data are currently resolvable on the CliMA cluster via the shared Overrides.toml.


<!-- Make sure to pick an unique name for your artifact -->
<!-- The easiest way to generate an artifact is using ClimaArtifactsHelper -->
<!-- ClimaArtifactsHelper generates ids and files for you -->

Checklist:
- [ ] I created a new folder `$artifact_name`
  - [ ] I added a `README.md` in that that folder that
    - [ ] describes the data and processing done to it
    - [ ] lists the sources of the raw data
    - [ ] lists the required citation, licenses
  - [ ] If applicable (e.g., for Creative Commons), I added a `LICENSE` file
  - [ ] I added the scripts that retrieve, process, and produce the artifact
  - [ ] I added the environment used for such scripts (typically, `Project.toml`
        and `Manifest.toml`)
  - [ ] I added the `OutputArtifacts.toml` file containing the information
        needed for package developers to add `$artifact_name` to their package
- [ ] I uploaded the artifact folder to the Caltech cluster (in
      `/resnick/groups/esm/ClimaArtifacts/artifacts/$artifact_name`)
- [ ] I added the relevant code to the `Overides.toml` on the Caltech Cluster
      (in `/resnick/groups/esm/ClimaArtifacts/artifacts/Overrides.toml`)
- [ ] I added a link to the main `README.md` to point to the new artifact
