### PR TITLE
Refresh README and LICENSE metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024-2026 California Institute of Technology (Climate Modeling Alliance)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Updated LICENSE copyright to `2024-2026 California Institute of Technology (Climate Modeling Alliance)`, using the repo's actual first-commit year (this line was previously an unfilled template placeholder).
